### PR TITLE
Experimental: buildkite CI

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,4 +1,6 @@
 steps:
   - command: 'cargo test --all'
+    env:
+        DOCKER_IMAGE: "rust:1.36.0-slim-buster"
     agents:
       rust: "true"

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,0 +1,4 @@
+steps:
+  - command: 'cargo test --all'
+    agents:
+      rust: "true"

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,6 +1,6 @@
 steps:
   - command: 'cargo test --all'
     env:
-        DOCKER_IMAGE: "rust:1.36.0-slim-buster"
+      DOCKER_IMAGE: "rust:1.36.0-slim-buster"
     agents:
-      rust: "true"
+      docker: "true"


### PR DESCRIPTION
This lets me experiment with buildkite agent configuration.

There are some limitations currently, including:

* No caching 
* ~~Fixed build environment (`rust:1.36.0-slim-buster` doge image)~~
* No buildkite plugins or hooks
* No build for 3rd party pull requests

Some of these will be possible in the future, others not because security.