### PR TITLE
CI: Custom docker image with sccache

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,6 +1,6 @@
 steps:
-  - command: 'cargo test --all'
+  - command: 'cargo test --features build-binary --all'
     env:
-      DOCKER_IMAGE: "rust:1.36.0-slim-buster"
+      DOCKER_IMAGE: "gcr.io/opensourcecoin/osrank-build:rustc-1.36.0"
     agents:
       docker: "true"

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -1,0 +1,18 @@
+FROM rust:1.36.0-slim-buster
+
+# Install additional packages
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libssl-dev \
+        pkg-config \
+    && apt-get autoremove \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install sccache
+RUN cargo install sccache \
+    && rm -rf /usr/local/cargo/registry \
+    && rm /usr/local/cargo/.package-cache
+
+# Setup defaults for sccache
+VOLUME /cache
+ENV SCCACHE_DIR=/cache/sccache RUSTC_WRAPPER=sccache


### PR DESCRIPTION
Built dependencies (and possibly other stuff) is now cached per-build-agent via [sccache](https://github.com/mozilla/sccache).

Note that we don't currently support building docker images on CI. Should the need for linear algebra re-arise at a later point (or other toolchain customisations, such as the rustc wasm target), please build the image locally and push it to the goog registry.