### PR TITLE
CSV Importer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -866,7 +866,6 @@ dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "csv 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "fraction 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,6 +879,7 @@ dependencies = [
  "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "sprs 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,18 +33,18 @@ required-features = ["build-binary"]
 
 [features]
 
-build-binary = ["csv", "reqwest", "clap"]
+build-binary = ["reqwest", "clap", "failure", "failure_derive"]
 
 [dependencies]
 
-serde = { version = "1.0.60", features = ["derive"]}
-serde_json = "1.0.40"
-failure = "0.1.5"
-failure_derive = "0.1.5"
-either = "^1.5"
 num-traits = "^0.2"
 derive_more = "^0.13"
 itertools = "^0.8.0"
+
+#Importers/exporters crates
+csv = "^1.1"
+serde = { version = "1.0.60", features = ["derive"]}
+serde_json = "1.0.40"
 
 #Linear algebra/math crates
 petgraph = "0.4.13"
@@ -56,9 +56,10 @@ rand = "^0.6.5"
 
 # Binary-only dependencies
 # See: https://stackoverflow.com/questions/35711044/how-can-i-specify-binary-only-dependencies
-csv = { version = "1.1", optional = true }
 reqwest = { version = "^0.9", optional = true }
 clap = { version = "^2.33", optional = true }
+failure = { version = "0.1.5", optional = true}
+failure_derive = { version = "0.1.5", optional = true}
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,3 +63,4 @@ failure_derive = { version = "0.1.5", optional = true}
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"
+tempfile = "^3.1.0"

--- a/bin/adjacency_matrix.rs
+++ b/bin/adjacency_matrix.rs
@@ -537,18 +537,9 @@ fn build_adjacency_matrix(
     println!("Computing the pagerank...");
     let pagerank_matrix = pagerank_naive_iterative(&network_t_norm, 0.85, outbound_links_factor);
 
-    let pagerank_matrix_labeled = Rank::from(
-        pagerank_matrix.labeled((
-            deps_meta
-                .labels
-                .iter()
-                .cloned()
-                .collect::<Vec<String>>()
-                .as_slice(),
-            &[],
-        )),
-    )
-    .unwrap_or_else(|e| panic!(e));
+    let pagerank_matrix_labeled =
+        Rank::from(pagerank_matrix.labeled((deps_meta.labels.to_vec().as_slice(), &[])))
+            .unwrap_or_else(|e| panic!(e));
 
     println!("Write the matrix to file (skipped for now)");
 

--- a/bin/adjacency_matrix.rs
+++ b/bin/adjacency_matrix.rs
@@ -18,7 +18,7 @@ use osrank::importers::csv::{
     new_contribution_adjacency_matrix, new_dependency_adjacency_matrix, ContribRow,
     ContributionsMetadata, CsvImportError, DepMetaRow, DependenciesMetadata,
 };
-use osrank::linalg::{hadamard_mul, transpose_storage, DenseMatrix, SparseMatrix};
+use osrank::linalg::{transpose_storage, DenseMatrix, SparseMatrix};
 use osrank::types::{HyperParams, Weight};
 use sprs::binop::{add_mat_same_storage, scalar_mul_mat};
 use sprs::CsMat;
@@ -148,14 +148,17 @@ where
     dense
 }
 
-fn debug_sparse_matrix_to_csv<N>(matrix: &CsMat<N>, out_path: &str) -> Result<(), CsvImportError>
+pub fn debug_sparse_matrix_to_csv<N>(
+    matrix: &CsMat<N>,
+    out_path: &str,
+) -> Result<(), CsvImportError>
 where
     N: DisplayAsF64 + Zero + Clone + Copy,
 {
     debug_dense_matrix_to_csv(&matrix.to_dense(), out_path)
 }
 
-fn debug_dense_matrix_to_csv<N>(
+pub fn debug_dense_matrix_to_csv<N>(
     matrix: &DenseMatrix<N>,
     out_path: &str,
 ) -> Result<(), CsvImportError>
@@ -271,7 +274,7 @@ fn build_adjacency_matrix(
         &dep_adj_matrix,
         &con_adj_matrix,
         &maintenance_matrix,
-        HyperParams::default(),
+        &HyperParams::default(),
     );
 
     println!("assert_normalised(network_matrix)");
@@ -364,7 +367,7 @@ mod tests {
     use num_traits::{One, Zero};
     use osrank::adjacency::new_network_matrix;
     use osrank::importers::csv::{ContributionsMetadata, DependenciesMetadata};
-    use osrank::linalg::{normalise_rows, normalise_rows_mut};
+    use osrank::linalg::{hadamard_mul, normalise_rows, normalise_rows_mut};
     use osrank::types::{HyperParams, Weight};
     use pretty_assertions::assert_eq;
     use sprs::{CsMat, TriMat, TriMatBase};
@@ -397,7 +400,7 @@ mod tests {
         );
 
         let input2 = input.clone();
-        let result = super::hadamard_mul(input, &input2);
+        let result = hadamard_mul(input, &input2);
 
         let expected = arr2(&[
             [64, 16, 1, 0],
@@ -494,7 +497,7 @@ mod tests {
         );
         let m = CsMat::csr_from_dense(arr2(&[[o, z, z], [z, o, z], [z, o, z]]).view(), z);
 
-        let network = new_network_matrix(&d, &c, &m, HyperParams::default());
+        let network = new_network_matrix(&d, &c, &m, &HyperParams::default());
 
         let expected = arr2(&[
             [z, Weight::new(4, 7), z, Weight::new(3, 7), z, z],

--- a/bin/main.rs
+++ b/bin/main.rs
@@ -15,6 +15,6 @@ fn main() -> Result<(), Box<std::error::Error>> {
 
     // Render to file
     println!("Rendering the network to a file..");
-    &cargo_network.to_graphviz_dot("rust_network.dot".as_ref())?;
+    cargo_network.to_graphviz_dot("rust_network.dot".as_ref())?;
     Ok(())
 }

--- a/bin/source_contributions.rs
+++ b/bin/source_contributions.rs
@@ -372,7 +372,7 @@ fn resumes<'a>(resume_from: Option<&'a str>) -> Box<FnMut(&StringRecord) -> bool
     })
 }
 
-const GITHUB_BASE_URL: &'static str = "https://api.github.com";
+const GITHUB_BASE_URL: &str = "https://api.github.com";
 
 fn main() -> Result<(), AppError> {
     let github_token = env::var("OSRANK_GITHUB_TOKEN")?;

--- a/src/adjacency.rs
+++ b/src/adjacency.rs
@@ -1,0 +1,53 @@
+#![allow(unknown_lints)]
+#![warn(clippy::all)]
+
+extern crate num_traits;
+extern crate serde;
+extern crate sprs;
+
+use crate::linalg::{hadamard_mul, normalise_rows, transpose_storage, SparseMatrix};
+use crate::types::{HyperParams, Weight};
+use num_traits::{Num, Signed};
+use sprs::binop::scalar_mul_mat;
+use sprs::{hstack, vstack, CsMat};
+
+/// Builds a new (normalised) network graph adjacency matrix.
+pub fn new_network_matrix<N>(
+    dep_matrix: &SparseMatrix<N>,
+    contrib_matrix: &SparseMatrix<N>,
+    maintainer_matrix: &SparseMatrix<N>,
+    hyperparams: HyperParams,
+) -> SparseMatrix<N>
+where
+    N: Num + Copy + Default + From<Weight> + PartialOrd + Signed,
+{
+    let contrib_t = transpose_storage(&contrib_matrix);
+    let contrib_t_norm = normalise_rows(&contrib_t);
+
+    let maintainer_t = maintainer_matrix.clone().transpose_into();
+    let maintainer_norm = normalise_rows(&maintainer_matrix);
+
+    let project_to_project = scalar_mul_mat(
+        &normalise_rows(&dep_matrix),
+        hyperparams.depend_factor.into(),
+    );
+    let project_to_account = &scalar_mul_mat(&maintainer_norm, hyperparams.maintain_factor.into())
+        + &scalar_mul_mat(
+            &normalise_rows(&contrib_matrix),
+            hyperparams.contrib_factor.into(),
+        );
+    let account_to_project =
+        &hadamard_mul(
+            scalar_mul_mat(&maintainer_t, hyperparams.maintain_prime_factor.into()),
+            &contrib_t_norm,
+        ) + &scalar_mul_mat(&contrib_t_norm, hyperparams.contrib_prime_factor.into());
+
+    let account_to_account: SparseMatrix<N> =
+        CsMat::zero((contrib_matrix.cols(), contrib_matrix.cols()));
+
+    // Join the matrixes together
+    let q1_q2 = hstack(&vec![project_to_project.view(), project_to_account.view()]);
+    let q3_q4 = hstack(&vec![account_to_project.view(), account_to_account.view()]);
+
+    normalise_rows(&vstack(&vec![q1_q2.view(), q3_q4.view()]))
+}

--- a/src/adjacency.rs
+++ b/src/adjacency.rs
@@ -16,7 +16,7 @@ pub fn new_network_matrix<N>(
     dep_matrix: &SparseMatrix<N>,
     contrib_matrix: &SparseMatrix<N>,
     maintainer_matrix: &SparseMatrix<N>,
-    hyperparams: HyperParams,
+    hyperparams: &HyperParams,
 ) -> SparseMatrix<N>
 where
     N: Num + Copy + Default + From<Weight> + PartialOrd + Signed,

--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -142,8 +142,7 @@ mod tests {
     use super::*;
     use crate::protocol_traits::ledger::MockLedger;
     use crate::types::{
-        AccountAttributes, Artifact, DampingFactors, Dependency, HyperParams, Network,
-        ProjectAttributes, Weight,
+        AccountAttributes, Artifact, Dependency, Network, ProjectAttributes, Weight,
     };
     use num_traits::Zero;
 
@@ -237,10 +236,7 @@ mod tests {
             Dependency::Influence(Weight::new(1, 1).as_f64().unwrap()),
         );
 
-        let mock_ledger = MockLedger {
-            params: HyperParams::default(),
-            factors: DampingFactors::default(),
-        };
+        let mock_ledger = MockLedger::default();
 
         assert_eq!(network.edge_count(), 11);
         assert_eq!(

--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -1,7 +1,6 @@
 #![allow(unknown_lints)]
 #![warn(clippy::all)]
 
-extern crate either;
 extern crate ndarray;
 extern crate petgraph;
 extern crate rand;

--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -1,3 +1,6 @@
+#![allow(unknown_lints)]
+#![warn(clippy::all)]
+
 extern crate either;
 extern crate ndarray;
 extern crate petgraph;
@@ -21,7 +24,7 @@ pub struct WalkResult<'a, G, I> {
     walks: RandomWalks<I>,
 }
 
-pub fn random_walk<'a, L, G>(
+pub fn random_walk<L, G>(
     seed_set: Option<SeedSet>,
     network: &'a G,
     ledger_view: &L,

--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -6,9 +6,9 @@ extern crate petgraph;
 extern crate rand;
 extern crate sprs;
 
-use crate::protocol_traits::graph::Graph;
+use crate::protocol_traits::graph::{Graph, GraphObject, Id, Metadata};
 use crate::protocol_traits::ledger::LedgerView;
-use crate::types::{Artifact, Dependency, Osrank, RandomWalk, RandomWalks, SeedSet};
+use crate::types::{Osrank, RandomWalk, RandomWalks, SeedSet};
 use fraction::Fraction;
 use rand::distributions::WeightedError;
 use rand::seq::SliceRandom;
@@ -27,26 +27,27 @@ pub struct WalkResult<'a, G, I> {
 // Dependency<W>, for I have ran into a cryptic error about the SampleBorrow
 // trait not be implemented, and wasn't able to immediately make the code
 // typecheck.
-pub fn random_walk<L, G>(
+pub fn random_walk<'a, L, G>(
     seed_set: Option<SeedSet>,
     network: &'a G,
     ledger_view: &L,
     iter: i32,
-) -> Result<WalkResult<'a, G, G::NodeId>, OsrankError>
+    get_weight: &Box<Fn(&<G::Edge as GraphObject>::Metadata) -> f64>,
+) -> Result<WalkResult<'a, G, <G::Node as GraphObject>::Id>, OsrankError>
 where
     L: LedgerView,
-    G: Graph<EdgeMetadata = Dependency<f64>>,
-    G::NodeId: PartialEq,
+    G: Graph,
+    Id<G::Node>: Clone + PartialEq,
 {
     match seed_set {
         Some(_) => unimplemented!(),
         None => {
             let mut walks = RandomWalks::new();
-            for i in network.node_ids() {
+            for i in network.nodes() {
                 for _ in 0..iter {
                     let mut walk = RandomWalk::new();
-                    walk.add_next(i);
-                    let mut current_node = i;
+                    walk.add_next(i.id().clone());
+                    let mut current_node = i.id();
                     // TODO distinguish account/project
                     // TODO Should there be a safeguard so this doesn't run forever?
                     while rand::thread_rng().gen::<f64>()
@@ -56,11 +57,11 @@ where
                         match neighbors.choose_weighted(&mut rand::thread_rng(), |item| {
                             network
                                 .lookup_edge_metadata(&item.id)
-                                .and_then(|m| Some(m.get_weight()))
+                                .and_then(|m| Some(get_weight(m)))
                                 .unwrap()
                         }) {
                             Ok(next_edge) => {
-                                walk.add_next(next_edge.target);
+                                walk.add_next(next_edge.target.clone());
                                 current_node = next_edge.target;
                             }
                             Err(WeightedError::NoItem) => break,
@@ -89,159 +90,182 @@ pub fn osrank_naive<L, G>(
     network: &mut G,
     ledger_view: &L,
     iter: i32,
+    get_weight: Box<Fn(&<G::Edge as GraphObject>::Metadata) -> f64>,
+    from_osrank: Box<(Fn(&G::Node, Osrank) -> Metadata<G::Node>)>,
 ) -> Result<(), OsrankError>
 where
     L: LedgerView,
-    G: Graph<NodeMetadata = Artifact, EdgeMetadata = Dependency>,
-    G::NodeId: PartialEq,
+    G: Graph,
+    Id<G::Node>: Clone + PartialEq,
 {
     match seed_set {
         Some(_) => {
             // Phase1, rank the network and produce a NetworkView.
-            let phase1 = random_walk(seed_set, &*network, ledger_view, iter)?;
+            let phase1 = random_walk(seed_set, &*network, ledger_view, iter, &get_weight)?;
             // Phase2, compute the osrank only on the NetworkView
-            let phase2 = random_walk(None, &*phase1.network_view, ledger_view, iter)?;
-            rank_network(&phase2.walks, &mut *network, ledger_view)
-        },
+            let phase2 = random_walk(None, &*phase1.network_view, ledger_view, iter, &get_weight)?;
+            rank_network(&phase2.walks, &mut *network, ledger_view, &from_osrank)
+        }
         None => {
             // Compute osrank on the full NetworkView
-            let create_walks = random_walk(None, &*network, ledger_view, iter)?;
-            rank_network(&create_walks.walks, &mut *network, ledger_view)
+            let create_walks = random_walk(None, &*network, ledger_view, iter, &get_weight)?;
+            rank_network(
+                &create_walks.walks,
+                &mut *network,
+                ledger_view,
+                &from_osrank,
+            )
         }
     }
 }
 
-pub fn rank_network<L, G>(
-    random_walks: &RandomWalks<G::NodeId>,
-    network_view: &mut G,
+pub fn rank_network<'a, L, G: 'a>(
+    random_walks: &RandomWalks<Id<G::Node>>,
+    network_view: &'a mut G,
     ledger_view: &L,
+    from_osrank: &Box<(Fn(&G::Node, Osrank) -> Metadata<G::Node>)>,
 ) -> Result<(), OsrankError>
 where
     L: LedgerView,
-    G: Graph<NodeMetadata = Artifact>,
-    G::NodeId: PartialEq,
+    G: Graph,
+    <G::Node as GraphObject>::Id: PartialEq + Clone,
 {
-    for node_idx in network_view.node_ids() {
+    for node in network_view.nodes_mut() {
         let total_walks = random_walks.len();
-        let node_visits = &random_walks.count_visits(node_idx);
+        let node_visits = &random_walks.count_visits(node.id().clone());
         let rank = Fraction::from(1.0 - ledger_view.get_damping_factors().project)
-            * Osrank::new(
-                *node_visits as u32,
-                total_walks as u32,
-            );
+            * Osrank::new(*node_visits as u32, total_walks as u32);
 
-        network_view.update_node_metadata(
-            &node_idx,
-            Box::new(move |metadata| metadata.set_osrank(rank)),
-        );
+        node.set_metadata(from_osrank(&node, rank))
     }
     Ok(())
 }
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::protocol_traits::ledger::MockLedger;
-    use crate::types::{
-        AccountAttributes, Artifact, Dependency, Network, ProjectAttributes, Weight,
-    };
+    use crate::types::{Artifact, ArtifactType, DependencyType, Network, Weight};
     use num_traits::Zero;
 
     #[test]
     fn everything_ok() {
         // build the example network
         let mut network = Network::default();
-        let p1 = Artifact::Project(ProjectAttributes {
-            id: "p1".to_string(),
-            osrank: Zero::zero(),
-        });
-        let p2 = Artifact::Project(ProjectAttributes {
-            id: "p2".to_string(),
-            osrank: Zero::zero(),
-        });
-        let p3 = Artifact::Project(ProjectAttributes {
-            id: "p3".to_string(),
-            osrank: Zero::zero(),
-        });
-        let a1 = Artifact::Account(AccountAttributes {
-            id: "a1".to_string(),
-            osrank: Zero::zero(),
-        });
-        let a2 = Artifact::Account(AccountAttributes {
-            id: "a2".to_string(),
-            osrank: Zero::zero(),
-        });
-        let a3 = Artifact::Account(AccountAttributes {
-            id: "a3".to_string(),
-            osrank: Zero::zero(),
-        });
-        network.add_node(p1);
-        network.add_node(p2);
-        network.add_node(p3);
-        network.add_node(a1);
-        network.add_node(a2);
-        network.add_node(a3);
+        network.add_node(
+            "p1".to_string(),
+            ArtifactType::Project {
+                osrank: Zero::zero(),
+            },
+        );
+        network.add_node(
+            "p2".to_string(),
+            ArtifactType::Project {
+                osrank: Zero::zero(),
+            },
+        );
+        network.add_node(
+            "p3".to_string(),
+            ArtifactType::Project {
+                osrank: Zero::zero(),
+            },
+        );
+        network.add_node(
+            "a1".to_string(),
+            ArtifactType::Project {
+                osrank: Zero::zero(),
+            },
+        );
+        network.add_node(
+            "a2".to_string(),
+            ArtifactType::Project {
+                osrank: Zero::zero(),
+            },
+        );
+        network.add_node(
+            "a3".to_string(),
+            ArtifactType::Project {
+                osrank: Zero::zero(),
+            },
+        );
         network.add_edge(
+            &"p1".to_string(),
+            &"a1".to_string(),
             0,
+            DependencyType::Influence(Weight::new(3, 7).as_f64().unwrap()),
+        );
+        network.add_edge(
+            &"a1".to_string(),
+            &"p1".to_string(),
+            1,
+            DependencyType::Influence(Weight::new(1, 1).as_f64().unwrap()),
+        );
+        network.add_edge(
+            &"p1".to_string(),
+            &"p2".to_string(),
+            2,
+            DependencyType::Influence(Weight::new(4, 7).as_f64().unwrap()),
+        );
+        network.add_edge(
+            &"p2".to_string(),
+            &"a2".to_string(),
             3,
-            Dependency::Influence(Weight::new(3, 7).as_f64().unwrap()),
+            DependencyType::Influence(Weight::new(1, 1).as_f64().unwrap()),
         );
         network.add_edge(
-            3,
-            0,
-            Dependency::Influence(Weight::new(1, 1).as_f64().unwrap()),
-        );
-        network.add_edge(
-            0,
-            1,
-            Dependency::Influence(Weight::new(4, 7).as_f64().unwrap()),
-        );
-        network.add_edge(
-            1,
+            &"a2".to_string(),
+            &"p2".to_string(),
             4,
-            Dependency::Influence(Weight::new(1, 1).as_f64().unwrap()),
+            DependencyType::Influence(Weight::new(1, 3).as_f64().unwrap()),
         );
         network.add_edge(
-            4,
-            1,
-            Dependency::Influence(Weight::new(1, 3).as_f64().unwrap()),
-        );
-        network.add_edge(
-            4,
-            2,
-            Dependency::Influence(Weight::new(2, 3).as_f64().unwrap()),
-        );
-        network.add_edge(
-            2,
-            4,
-            Dependency::Influence(Weight::new(11, 28).as_f64().unwrap()),
-        );
-        network.add_edge(
-            2,
+            &"a2".to_string(),
+            &"p3".to_string(),
             5,
-            Dependency::Influence(Weight::new(1, 28).as_f64().unwrap()),
+            DependencyType::Influence(Weight::new(2, 3).as_f64().unwrap()),
         );
         network.add_edge(
-            2,
-            0,
-            Dependency::Influence(Weight::new(2, 7).as_f64().unwrap()),
+            &"p3".to_string(),
+            &"a2".to_string(),
+            6,
+            DependencyType::Influence(Weight::new(11, 28).as_f64().unwrap()),
         );
         network.add_edge(
-            2,
-            1,
-            Dependency::Influence(Weight::new(2, 7).as_f64().unwrap()),
+            &"p3".to_string(),
+            &"a3".to_string(),
+            7,
+            DependencyType::Influence(Weight::new(1, 28).as_f64().unwrap()),
         );
         network.add_edge(
-            5,
-            2,
-            Dependency::Influence(Weight::new(1, 1).as_f64().unwrap()),
+            &"p3".to_string(),
+            &"p1".to_string(),
+            8,
+            DependencyType::Influence(Weight::new(2, 7).as_f64().unwrap()),
+        );
+        network.add_edge(
+            &"p3".to_string(),
+            &"p2".to_string(),
+            9,
+            DependencyType::Influence(Weight::new(2, 7).as_f64().unwrap()),
+        );
+        network.add_edge(
+            &"a3".to_string(),
+            &"p3".to_string(),
+            10,
+            DependencyType::Influence(Weight::new(1, 1).as_f64().unwrap()),
         );
 
         let mock_ledger = MockLedger::default();
+        let get_weight = Box::new(|m: &DependencyType<f64>| *m.get_weight());
+        let set_osrank = Box::new(|node: &Artifact<String>, rank| match node.get_metadata() {
+            ArtifactType::Project { osrank: _ } => ArtifactType::Project { osrank: rank },
+            ArtifactType::Account { osrank: _ } => ArtifactType::Account { osrank: rank },
+        });
 
         assert_eq!(network.edge_count(), 11);
         assert_eq!(
-            osrank_naive(None, &mut network, &mock_ledger, 10).unwrap(),
+            osrank_naive(None, &mut network, &mock_ledger, 10, get_weight, set_osrank).unwrap(),
             ()
-        );
+        )
     }
 }

--- a/src/importers/csv.rs
+++ b/src/importers/csv.rs
@@ -1,21 +1,199 @@
 #![allow(unknown_lints)]
 #![warn(clippy::all)]
 
+extern crate num_traits;
+extern crate serde;
+extern crate sprs;
+
+use crate::linalg::SparseMatrix;
 use crate::protocol_traits::graph::Graph;
 use crate::protocol_traits::ledger::LedgerView;
+use core::fmt;
+use num_traits::{Num, One};
+use serde::Deserialize;
+use sprs::{TriMat, TriMatBase};
+use std::collections::{HashMap, HashSet};
+use std::fs::File;
+use std::io::Read;
 use std::path::Path;
 
-pub enum CsvImporterError {}
+//
+// Types
+//
+
+type ProjectId = u32;
+type ProjectName = String;
+type Contributor = String;
+// We need a way to map external indexes with an incremental index suitable
+// for matrix manipulation, so we define this LocalMatrixIndex exactly for
+// this purpose.
+type LocalMatrixIndex = usize;
+
+pub type DependencyMatrix<N> = SparseMatrix<N>;
+pub type ContributionMatrix<N> = SparseMatrix<N>;
+pub type MaintenanceMatrix<N> = SparseMatrix<N>;
+
+#[derive(Debug, Deserialize)]
+pub struct DepMetaRow {
+    pub id: u32,
+    pub name: String,
+    pub platform: String,
+}
+
+pub struct DependenciesMetadata {
+    pub ids: HashSet<ProjectId>,
+    pub labels: Vec<ProjectName>,
+    pub project2index: HashMap<ProjectId, LocalMatrixIndex>,
+}
+
+impl DependenciesMetadata {
+    pub fn new() -> Self {
+        DependenciesMetadata {
+            ids: Default::default(),
+            labels: Default::default(),
+            project2index: Default::default(),
+        }
+    }
+}
+
+pub struct ContributionsMetadata {
+    pub contributors: HashSet<Contributor>,
+    pub contributor2index: HashMap<Contributor, LocalMatrixIndex>,
+}
+
+impl ContributionsMetadata {
+    pub fn new() -> Self {
+        ContributionsMetadata {
+            contributors: Default::default(),
+            contributor2index: Default::default(),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ContribRow {
+    pub project_id: ProjectId,
+    pub contributor: String,
+    pub repo: String,
+    pub contributions: u32,
+    pub project_name: ProjectName,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct DepRow {
+    pub from: ProjectId,
+    pub to: ProjectId,
+}
+
+//
+// Errors
+//
+
+#[derive(Debug)]
+pub enum CsvImportError {
+    // Returned in case of generic I/O error.
+    IOError(std::io::Error),
+
+    // Returned when the CSV deserialisation failed.
+    CsvDeserialisationError(csv::Error),
+}
+
+impl fmt::Display for CsvImportError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            CsvImportError::IOError(e) => {
+                write!(f, "i/o error when reading/writing on the CSV file {}", e)
+            }
+            CsvImportError::CsvDeserialisationError(e) => {
+                write!(f, "Deserialisation failed on a CSV row {}", e)
+            }
+        }
+    }
+}
+
+impl From<std::io::Error> for CsvImportError {
+    fn from(err: std::io::Error) -> CsvImportError {
+        CsvImportError::IOError(err)
+    }
+}
+
+impl From<csv::Error> for CsvImportError {
+    fn from(err: csv::Error) -> CsvImportError {
+        CsvImportError::CsvDeserialisationError(err)
+    }
+}
 
 pub fn from_csv_files<G, L>(
     deps_csv_file: &Path,
     deps_meta_csv_file: &Path,
     contrib_csv_file: &Path,
     ledger_view: &L,
-) -> Result<G, CsvImporterError>
+) -> Result<G, CsvImportError>
 where
     G: Graph,
     L: LedgerView,
 {
     unimplemented!()
+}
+
+/// Creates a (sparse) adjacency matrix for the dependencies.
+/// Corresponds to the "cargo-dep-adj.csv" from the Python scripts.
+pub fn new_dependency_adjacency_matrix<N>(
+    deps_meta: &DependenciesMetadata,
+    deps_csv: csv::Reader<File>,
+) -> Result<DependencyMatrix<N>, CsvImportError>
+where
+    N: Num + Clone,
+{
+    let mut dep_adj: TriMat<N> = TriMatBase::new((deps_meta.ids.len(), deps_meta.ids.len()));
+
+    // Iterate through the dependencies, populating the matrix.
+    for result in deps_csv.into_records().filter_map(|e| e.ok()) {
+        let row: DepRow = result.deserialize(None)?;
+        if let (Some(from_index), Some(to_index)) = (
+            deps_meta.project2index.get(&row.from),
+            deps_meta.project2index.get(&row.to),
+        ) {
+            dep_adj.add_triplet(*from_index as usize, *to_index as usize, One::one());
+        }
+    }
+
+    Ok(dep_adj.to_csr())
+}
+
+/// Creates a (sparse) adjacency matrix for the contributions.
+/// Corresponds to the "cargo-contrib-adj.csv" from the Python scripts.
+pub fn new_contribution_adjacency_matrix<F, N>(
+    deps_meta: &DependenciesMetadata,
+    contribs_meta: &ContributionsMetadata,
+    contribs_csv: csv::Reader<F>,
+    mk_contribution: Box<dyn Fn(u32) -> N>,
+) -> Result<ContributionMatrix<N>, CsvImportError>
+where
+    F: Read,
+    N: Num + Clone,
+{
+    // Creates a sparse matrix of projects x contributors
+    let mut contrib_adj: TriMat<N> =
+        TriMatBase::new((deps_meta.ids.len(), contribs_meta.contributors.len()));
+
+    for result in contribs_csv.into_records().filter_map(|e| e.ok()) {
+        let row: ContribRow = result.deserialize(None)?;
+
+        if let Some((row_ix, col_ix)) =
+            deps_meta
+                .project2index
+                .get(&row.project_id)
+                .and_then(|row_ix| {
+                    contribs_meta
+                        .contributor2index
+                        .get(&row.contributor)
+                        .map(|col| (*row_ix, *col))
+                })
+        {
+            contrib_adj.add_triplet(row_ix, col_ix, mk_contribution(row.contributions))
+        }
+    }
+
+    Ok(contrib_adj.to_csr())
 }

--- a/src/importers/csv.rs
+++ b/src/importers/csv.rs
@@ -32,10 +32,14 @@ type Contributor = String;
 // this purpose.
 type LocalMatrixIndex = usize;
 
+/// The `SparseMatrix` of the dependencies.
 pub type DependencyMatrix<N> = SparseMatrix<N>;
+/// The `SparseMatrix` of the contributions.
 pub type ContributionMatrix<N> = SparseMatrix<N>;
+/// The `SparseMatrix` of the maintainers.
 pub type MaintenanceMatrix<N> = SparseMatrix<N>;
 
+/// A single, deserialised row of the `{platform}_dependencies_meta.csv` file.
 #[derive(Debug, Deserialize)]
 pub struct DepMetaRow {
     pub id: u32,
@@ -85,6 +89,7 @@ impl Default for ContributionsMetadata {
     }
 }
 
+/// A single, deserialised row of the `{platform}_contributors.csv` file.
 #[derive(Debug, Deserialize)]
 pub struct ContribRow {
     pub project_id: ProjectId,
@@ -94,6 +99,7 @@ pub struct ContribRow {
     pub project_name: ProjectName,
 }
 
+/// A single, deserialised row of the `{platform}_dependencies.csv` file.
 #[derive(Debug, Deserialize)]
 pub struct DepRow {
     pub from: ProjectId,
@@ -104,12 +110,13 @@ pub struct DepRow {
 // Errors
 //
 
+/// Errors arising during the import process.
 #[derive(Debug)]
 pub enum CsvImportError {
-    // Returned in case of generic I/O error.
+    /// Returned in case of generic I/O error.
     IOError(std::io::Error),
 
-    // Returned when the CSV deserialisation failed.
+    /// Returned when the CSV deserialisation failed.
     CsvDeserialisationError(csv::Error),
 }
 
@@ -138,7 +145,42 @@ impl From<csv::Error> for CsvImportError {
     }
 }
 
-pub fn import_network<G, L>(
+/// Constructs a `Network` graph from a list of CSVs. The structure of each
+/// csv is important, and is documented below.
+///
+/// #deps_csv_file
+///
+/// This must be a csv file in this format:
+///
+/// ```
+/// FROM_ID,TO_ID
+/// 30742,31187
+/// 30742,31296
+/// [..]
+/// ```
+///
+/// #deps_meta_csv_file
+/// This must be a csv file in this format:
+///
+/// ```
+/// ID,NAME,PLATFORM
+/// 30742,acacia,Cargo
+/// 30745,aio,Cargo
+/// 30746,advapi32-sys,Cargo
+/// [..]
+/// ```
+///
+/// #contrib_csv_file
+/// This must be a csv file in this format:
+///
+/// ```
+/// ID,MAINTAINER,REPO,CONTRIBUTIONS,NAME
+/// 30742,github@aepsil0n,https://github.com/aepsil0n/acacia,118,acacia
+/// 30743,github@emk,https://github.com/emk/abort_on_panic-rs,32,abort_on_panic
+/// 30745,github@reem,https://github.com/reem/rust-aio,35,aio
+/// [..]
+/// ```
+pub fn import_network<L>(
     deps_csv_file: &Path,
     deps_meta_csv_file: &Path,
     contrib_csv_file: &Path,

--- a/src/importers/csv.rs
+++ b/src/importers/csv.rs
@@ -1,0 +1,21 @@
+#![allow(unknown_lints)]
+#![warn(clippy::all)]
+
+use crate::protocol_traits::graph::Graph;
+use crate::protocol_traits::ledger::LedgerView;
+use std::path::Path;
+
+pub enum CsvImporterError {}
+
+pub fn from_csv_files<G, L>(
+    deps_csv_file: &Path,
+    deps_meta_csv_file: &Path,
+    contrib_csv_file: &Path,
+    ledger_view: &L,
+) -> Result<G, CsvImporterError>
+where
+    G: Graph,
+    L: LedgerView,
+{
+    unimplemented!()
+}

--- a/src/importers/gephi_json.rs
+++ b/src/importers/gephi_json.rs
@@ -23,7 +23,7 @@ pub struct GephiEdge {
 
 /// Construct a Network out of a Gephi json file. Only projects are supported
 /// for now.
-pub fn from_gephi_json(nodes: Vec<GephiNode>, edges: Vec<GephiEdge>) -> Network {
+pub fn from_gephi_json(nodes: Vec<GephiNode>, edges: Vec<GephiEdge>) -> Network<Weight> {
     let mut network = Network::default();
     for node in nodes {
         let project = Artifact::Project(ProjectAttributes {

--- a/src/importers/gephi_json.rs
+++ b/src/importers/gephi_json.rs
@@ -3,7 +3,7 @@ extern crate serde;
 extern crate serde_json;
 
 use crate::protocol_traits::graph::Graph;
-use crate::types::{Artifact, Dependency, Network, ProjectAttributes, Weight};
+use crate::types::{ArtifactType, DependencyType, Network, Weight};
 use num_traits::Zero;
 use serde::Deserialize;
 use serde_json::Value;
@@ -26,18 +26,17 @@ pub struct GephiEdge {
 pub fn from_gephi_json(nodes: Vec<GephiNode>, edges: Vec<GephiEdge>) -> Network<Weight> {
     let mut network = Network::default();
     for node in nodes {
-        let project = Artifact::Project(ProjectAttributes {
-            id: node.id,
+        let project_meta = ArtifactType::Project {
             osrank: Zero::zero(),
-        });
-        network.add_node(project);
+        };
+        network.add_node(node.id, project_meta);
     }
 
-    for edge in edges {
+    for (ix, edge) in edges.iter().enumerate() {
         //FIXME(adn) This should take into account normalisation and
         //redistribution of the weights etc.
-        let depends_on = Dependency::Depend(Weight::new(1, 1));
-        network.add_edge(edge.s, edge.t, depends_on)
+        let depends_on = DependencyType::Depend(Weight::new(1, 1));
+        network.add_edge(&edge.s.to_string(), &edge.t.to_string(), ix, depends_on)
     }
 
     network

--- a/src/importers/mod.rs
+++ b/src/importers/mod.rs
@@ -1,1 +1,2 @@
+pub mod csv;
 pub mod gephi_json;

--- a/src/importers/mod.rs
+++ b/src/importers/mod.rs
@@ -1,2 +1,5 @@
+/// Builds a `Network` graph from some key CSV files.
 pub mod csv;
+
+/// Builds a `Network` graph from a Gephi JSON file.
 pub mod gephi_json;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #[macro_use]
 extern crate derive_more;
 
+pub mod adjacency;
 pub mod algorithm;
 pub mod collections;
 pub mod exporters;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,5 +5,6 @@ pub mod algorithm;
 pub mod collections;
 pub mod exporters;
 pub mod importers;
+pub mod linalg;
 pub mod protocol_traits;
 pub mod types;

--- a/src/linalg.rs
+++ b/src/linalg.rs
@@ -1,0 +1,57 @@
+extern crate ndarray;
+extern crate sprs;
+
+use ndarray::Array2;
+use num_traits::{Num, Signed, Zero};
+use sprs::CsMat;
+
+pub type SparseMatrix<N> = CsMat<N>;
+pub type DenseMatrix<N> = Array2<N>;
+
+pub fn transpose_storage<N>(matrix: &SparseMatrix<N>) -> SparseMatrix<N>
+where
+    N: Num + Copy + Signed + PartialOrd + Default,
+{
+    CsMat::csr_from_dense(matrix.to_dense().t().view(), N::zero())
+}
+
+/// Inefficient implementation of the Hadamard multiplication that operates
+/// on the dense representation.
+pub fn hadamard_mul<N>(lhs: SparseMatrix<N>, rhs: &SparseMatrix<N>) -> SparseMatrix<N>
+where
+    N: Zero + PartialOrd + Signed + Clone,
+{
+    CsMat::csr_from_dense((lhs.to_dense() * rhs.to_dense()).view(), Zero::zero())
+}
+
+/// Normalises the rows of a Matrix.
+/// N.B. It returns a brand new Matrix, therefore it performs a copy.
+/// FIXME(adn) Is there a way to yield only a (partial) view copying only
+/// the values?
+pub fn normalise_rows<N>(matrix: &SparseMatrix<N>) -> SparseMatrix<N>
+where
+    N: Num + Copy,
+{
+    let mut cloned = matrix.clone();
+    normalise_rows_mut(&mut cloned);
+    cloned
+}
+
+/// Normalises the rows for the input matrix.
+pub fn normalise_rows_mut<N>(matrix: &mut CsMat<N>)
+where
+    N: Num + Copy,
+{
+    for mut row_vec in matrix.outer_iterator_mut() {
+        let mut ixs = Vec::new();
+        let norm = row_vec.iter().fold(N::zero(), |acc, v| {
+            ixs.push(v.0);
+            acc + *(v.1)
+        });
+        if norm != N::zero() {
+            for ix in ixs {
+                row_vec[ix] = row_vec[ix] / norm;
+            }
+        }
+    }
+}

--- a/src/linalg.rs
+++ b/src/linalg.rs
@@ -1,3 +1,6 @@
+#![allow(unknown_lints)]
+#![warn(clippy::all)]
+
 extern crate ndarray;
 extern crate sprs;
 

--- a/src/protocol_traits/graph.rs
+++ b/src/protocol_traits/graph.rs
@@ -185,11 +185,5 @@ impl<'a, N: 'a> Iterator for NodesMut<'a, N> {
 
     fn next(&mut self) -> Option<Self::Item> {
         self.range.next()
-        //let f = &mut self.to_node_id;
-
-        //match self.range.next() {
-        //    None => None,
-        //    Some(v) => Some(f(v)),
-        //}
     }
 }

--- a/src/protocol_traits/graph.rs
+++ b/src/protocol_traits/graph.rs
@@ -1,7 +1,6 @@
 #![allow(unknown_lints)]
 #![warn(clippy::all)]
 
-extern crate either;
 extern crate rand;
 
 use std::ops::Range;

--- a/src/protocol_traits/ledger.rs
+++ b/src/protocol_traits/ledger.rs
@@ -34,6 +34,7 @@ pub trait LedgerView {
 }
 
 /// A `MockLedger` implementation, suitable for tests.
+#[derive(Default)]
 pub struct MockLedger {
     pub params: HyperParams,
     pub factors: DampingFactors,

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,6 @@
+#![allow(unknown_lints)]
+#![warn(clippy::all)]
+
 extern crate fraction;
 extern crate num_traits;
 extern crate petgraph;

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,17 +5,20 @@ extern crate fraction;
 extern crate num_traits;
 extern crate petgraph;
 
+use std::collections::HashMap;
 use std::fmt;
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::ops::{Div, Mul, Rem};
 use std::path::Path;
 
-use crate::protocol_traits::graph::{EdgeReference, Graph, NodeIds};
+use crate::protocol_traits::graph::{
+    EdgeReference, EdgeReferences, Graph, GraphObject, Id, Metadata, Nodes, NodesMut,
+};
 use fraction::{Fraction, GenericFraction};
 use num_traits::{Num, One, Signed, Zero};
 use petgraph::dot::{Config, Dot};
-use petgraph::graph::{edge_index, node_index, NodeIndex};
+use petgraph::graph::{node_index, EdgeIndex, NodeIndex};
 use petgraph::visit::EdgeRef;
 use petgraph::Directed;
 
@@ -254,7 +257,27 @@ impl Default for DampingFactors {
 }
 
 #[derive(Debug)]
-pub enum Dependency<W> {
+pub struct Dependency<Id, W> {
+    id: Id,
+    dependency_type: DependencyType<W>,
+}
+
+impl<Id, W> fmt::Display for Dependency<Id, W>
+where
+    W: fmt::Display,
+    Id: fmt::Display,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(
+            f,
+            "Dependency [ id = {}, type = {} ]",
+            self.id, self.dependency_type
+        )
+    }
+}
+
+#[derive(Debug)]
+pub enum DependencyType<W> {
     Contrib(W),
     ContribPrime(W),
     Maintain(W),
@@ -266,72 +289,98 @@ pub enum Dependency<W> {
     Influence(W),
 }
 
-impl<W> fmt::Display for Dependency<W>
+impl<W> fmt::Display for DependencyType<W>
 where
     W: fmt::Display,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         match self {
-            Dependency::Contrib(ref w) => write!(f, "{:.5}", w),
-            Dependency::ContribPrime(ref w) => write!(f, "{:.5}", w),
-            Dependency::Maintain(ref w) => write!(f, "{:.5}", w),
-            Dependency::MaintainPrime(ref w) => write!(f, "{:.5}", w),
-            Dependency::Depend(ref w) => write!(f, "{:.5}", w),
-            Dependency::Influence(ref w) => write!(f, "{:.5}", w),
+            DependencyType::Contrib(ref w) => write!(f, "{:.5}", w),
+            DependencyType::ContribPrime(ref w) => write!(f, "{:.5}", w),
+            DependencyType::Maintain(ref w) => write!(f, "{:.5}", w),
+            DependencyType::MaintainPrime(ref w) => write!(f, "{:.5}", w),
+            DependencyType::Depend(ref w) => write!(f, "{:.5}", w),
+            DependencyType::Influence(ref w) => write!(f, "{:.5}", w),
         }
     }
 }
 
-impl<W> Dependency<W> {
+impl<W> DependencyType<W> {
     pub fn get_weight(&self) -> &W {
         match self {
-            Dependency::Contrib(ref w) => w,
-            Dependency::ContribPrime(ref w) => w,
-            Dependency::Maintain(ref w) => w,
-            Dependency::MaintainPrime(ref w) => w,
-            Dependency::Depend(ref w) => w,
-            Dependency::Influence(ref w) => w,
+            DependencyType::Contrib(ref w) => w,
+            DependencyType::ContribPrime(ref w) => w,
+            DependencyType::Maintain(ref w) => w,
+            DependencyType::MaintainPrime(ref w) => w,
+            DependencyType::Depend(ref w) => w,
+            DependencyType::Influence(ref w) => w,
         }
     }
 }
 
-#[derive(Debug, PartialEq, Eq, PartialOrd)]
-pub struct ProjectAttributes {
-    pub id: String,
-    pub osrank: Osrank,
-}
+impl<DependencyId, W> GraphObject for Dependency<DependencyId, W> {
+    type Id = DependencyId;
+    type Metadata = DependencyType<W>;
 
-#[derive(Debug, PartialOrd, Eq, PartialEq)]
-pub struct AccountAttributes {
-    pub id: String,
-    pub osrank: Osrank,
+    fn id(&self) -> &Self::Id {
+        &self.id
+    }
+
+    fn get_metadata(&self) -> &Self::Metadata {
+        &self.dependency_type
+    }
+
+    fn set_metadata(&mut self, v: Self::Metadata) {
+        self.dependency_type = v;
+    }
 }
 
 #[derive(Debug, PartialOrd, PartialEq, Eq)]
-pub enum Artifact {
-    Project(ProjectAttributes),
-    Account(AccountAttributes),
+pub struct Artifact<Id> {
+    id: Id,
+    artifact_type: ArtifactType,
 }
 
-impl Artifact {
-    // Set the osrank attribute of the Artifact
-    pub fn set_osrank(&mut self, rank: Osrank) {
+#[derive(Debug, PartialOrd, PartialEq, Eq)]
+pub enum ArtifactType {
+    Project { osrank: Osrank },
+    Account { osrank: Osrank },
+}
+
+impl ArtifactType {
+    pub fn set_osrank(&mut self, new: Osrank) {
         match self {
-            Artifact::Project(attrs) => attrs.osrank = rank,
-            Artifact::Account(attrs) => attrs.osrank = rank,
+            ArtifactType::Project { ref mut osrank } => *osrank = new,
+            ArtifactType::Account { ref mut osrank } => *osrank = new,
         }
     }
 }
 
-impl fmt::Display for Artifact {
+impl<ArtifactId> GraphObject for Artifact<ArtifactId> {
+    type Id = ArtifactId;
+    type Metadata = ArtifactType;
+
+    fn id(&self) -> &Self::Id {
+        &self.id
+    }
+
+    fn get_metadata(&self) -> &Self::Metadata {
+        &self.artifact_type
+    }
+
+    fn set_metadata(&mut self, v: Self::Metadata) {
+        self.artifact_type = v
+    }
+}
+
+impl<Id> fmt::Display for Artifact<Id>
+where
+    Id: fmt::Display,
+{
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        match self {
-            Artifact::Project(ref attrs) => {
-                write!(f, "id: {} osrank: {:.5}", attrs.id, attrs.osrank)
-            }
-            Artifact::Account(ref attrs) => {
-                write!(f, "id: {} osrank: {:.5}", attrs.id, attrs.osrank)
-            }
+        match self.artifact_type {
+            ArtifactType::Project { osrank } => write!(f, "id: {} osrank: {:.5}", self.id, osrank),
+            ArtifactType::Account { osrank } => write!(f, "id: {} osrank: {:.5}", self.id, osrank),
         }
     }
 }
@@ -339,7 +388,9 @@ impl fmt::Display for Artifact {
 /// The network graph from the paper, comprising of both accounts and projects.
 #[derive(Debug, Default)]
 pub struct Network<W> {
-    from_graph: petgraph::Graph<Artifact, Dependency<W>, Directed>,
+    from_graph: petgraph::Graph<Artifact<String>, Dependency<usize, W>, Directed>,
+    node_ids: HashMap<String, NodeIndex>,
+    edge_ids: HashMap<usize, EdgeIndex>,
 }
 
 impl<W> Network<W>
@@ -347,17 +398,32 @@ where
     W: fmt::Display,
 {
     /// Adds an Artifact to the Network.
-    fn add_artifact(&mut self, artifact: Artifact) {
-        let _ = self.from_graph.add_node(artifact);
+    fn add_artifact(&mut self, id: String, artifact_type: ArtifactType) {
+        let id_cloned = id.clone();
+        let a = Artifact { id, artifact_type };
+        let nid = self.from_graph.add_node(a);
+
+        self.node_ids.insert(id_cloned, nid);
     }
 
     /// Adds a Dependency to the Network. It's unsafe in the sense it's
     /// callers' responsibility to ensure that the source and target exist
     /// in the input Network.
-    fn unsafe_add_dependency(&mut self, source: u32, target: u32, dependency: Dependency<W>) {
-        let _ =
-            self.from_graph
-                .add_edge(NodeIndex::from(source), NodeIndex::from(target), dependency);
+    fn unsafe_add_dependency(
+        &mut self,
+        source: usize,
+        target: usize,
+        id: usize,
+        dependency_type: DependencyType<W>,
+    ) {
+        let d = Dependency {
+            id,
+            dependency_type,
+        };
+        let eid = self
+            .from_graph
+            .add_edge(node_index(source), node_index(target), d);
+        self.edge_ids.insert(id, eid);
     }
 
     /// Debug-only function to render a Network into a Graphiz dot file.
@@ -378,41 +444,79 @@ impl<W> Graph for Network<W>
 where
     W: Default + fmt::Display,
 {
-    type NodeId = usize;
-    type EdgeId = usize;
-    type NodeMetadata = Artifact;
-    type EdgeMetadata = Dependency<W>;
+    type Node = Artifact<String>;
+    type Edge = Dependency<usize, W>;
 
-    fn add_node(&mut self, node_metadata: Self::NodeMetadata) {
-        self.add_artifact(node_metadata)
+    fn add_node(&mut self, node_id: Id<Self::Node>, node_metadata: Metadata<Self::Node>) {
+        self.add_artifact(node_id, node_metadata);
     }
 
     fn add_edge(
         &mut self,
-        source: Self::NodeId,
-        target: Self::NodeId,
-        edge_metadata: Self::EdgeMetadata,
+        source: &Id<Self::Node>,
+        target: &Id<Self::Node>,
+        edge_id: Id<Self::Edge>,
+        edge_metadata: Metadata<Self::Edge>,
     ) {
-        self.unsafe_add_dependency(source as u32, target as u32, edge_metadata)
+        //NOTE(adn) Should we return a `Result` rather than blowing everything up?
+        match self
+            .node_ids
+            .get(source)
+            .iter()
+            .zip(self.node_ids.get(target).iter())
+            .next()
+        {
+            Some((s, t)) => {
+                let src = (*s).index();
+                let tgt = (*t).index();
+                self.unsafe_add_dependency(src, tgt, edge_id, edge_metadata);
+            }
+            None => panic!(
+                "add_adge: invalid link, source {} or target {} are missing.",
+                source, target
+            ),
+        }
     }
 
-    fn neighbours(&self, node_id: &Self::NodeId) -> Vec<EdgeReference<Self::NodeId, Self::EdgeId>> {
+    fn neighbours(
+        &self,
+        node_id: &Id<Self::Node>,
+    ) -> EdgeReferences<Id<Self::Node>, Id<Self::Edge>> {
         let mut neighbours = Vec::default();
-        for eref in self.from_graph.edges(node_index(*node_id)) {
-            neighbours.push(EdgeReference {
-                source: eref.source().index(),
-                target: eref.target().index(),
-                id: eref.id().index(),
-            })
+
+        if let Some(nid) = self.node_ids.get(node_id) {
+            for eref in self.from_graph.edges(*nid) {
+                neighbours.push(EdgeReference {
+                    source: self.from_graph[eref.source()].id(),
+                    target: self.from_graph[eref.target()].id(),
+                    id: self.from_graph[eref.id()].id(),
+                })
+            }
         }
 
         neighbours
     }
 
-    fn node_ids(&self) -> NodeIds<Self::NodeId> {
-        NodeIds {
+    fn nodes(&self) -> Nodes<Self::Node> {
+        Nodes {
             range: 0..self.from_graph.node_count(),
-            to_node_id: Box::new(move |i| i),
+            to_node_id: Box::new(move |i| &self.from_graph[node_index(i)]),
+        }
+    }
+
+    fn nodes_mut(&mut self) -> NodesMut<Self::Node> {
+        NodesMut {
+            // NOTE(adn) Not the most efficient iterator, but due to my
+            // limited Rust-fu, I couldn't find anything better.
+            range: {
+                let mut v = Vec::default();
+
+                for n in self.from_graph.node_weights_mut() {
+                    v.push(n);
+                }
+
+                v.into_iter()
+            },
         }
     }
 
@@ -420,37 +524,37 @@ where
         self.from_graph.edge_count()
     }
 
-    fn lookup_node_metadata(&self, node_id: &Self::NodeId) -> Option<&Self::NodeMetadata> {
-        Some(&self.from_graph[node_index(*node_id)])
+    fn lookup_node_metadata(&self, node_id: &Id<Self::Node>) -> Option<&Metadata<Self::Node>> {
+        self.node_ids
+            .get(node_id)
+            .and_then(|n| Some(self.from_graph[*n].get_metadata()))
     }
-    fn lookup_edge_metadata(&self, edge_id: &Self::EdgeId) -> Option<&Self::EdgeMetadata> {
-        Some(&self.from_graph[edge_index(*edge_id)])
-    }
-
-    fn set_node_metadata(&mut self, node_id: &Self::NodeId, new: Self::NodeMetadata) {
-        self.from_graph[node_index(*node_id)] = new
-    }
-
-    fn update_node_metadata(
-        &mut self,
-        node_id: &Self::NodeId,
-        mut update_fn: Box<FnMut(&mut Self::NodeMetadata) -> ()>,
-    ) {
-        update_fn(&mut self.from_graph[node_index(*node_id)])
+    fn lookup_edge_metadata(&self, edge_id: &Id<Self::Edge>) -> Option<&Metadata<Self::Edge>> {
+        self.edge_ids
+            .get(edge_id)
+            .and_then(|e| Some(self.from_graph[*e].get_metadata()))
     }
 
-    fn set_edge_metadata(&mut self, edge_id: &Self::EdgeId, new: Self::EdgeMetadata) {
-        self.from_graph[edge_index(*edge_id)] = new
+    fn set_node_metadata(&mut self, node_id: &Id<Self::Node>, new: Metadata<Self::Node>) {
+        if let Some(nid) = self.node_ids.get(node_id) {
+            self.from_graph[*nid].set_metadata(new)
+        }
+    }
+
+    fn set_edge_metadata(&mut self, edge_id: &Id<Self::Edge>, new: Metadata<Self::Edge>) {
+        if let Some(eid) = self.edge_ids.get(edge_id) {
+            self.from_graph[*eid].set_metadata(new)
+        }
     }
 }
 
 /// Trait to print (parts of) the for debugging purposes
-pub trait PrintableGraph: Graph {
+pub trait PrintableGraph<'a>: Graph {
     /// Prints all nodes and their attributes
     fn print_nodes(&self);
 }
 
-impl<W> PrintableGraph for Network<W>
+impl<'a, W> PrintableGraph<'a> for Network<W>
 where
     W: Default + fmt::Display,
 {

--- a/src/types.rs
+++ b/src/types.rs
@@ -276,7 +276,7 @@ where
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum DependencyType<W> {
     Contrib(W),
     ContribPrime(W),


### PR DESCRIPTION
This PR completely overhauls the `Graph` protocol trait (as well as `types.rs`) and makes it closer to the vision described by @cloudhead (which might be interested to also review this work).

I am sure this won't be the _last_ time we modify these traits, but now I think it's definitely better than it was before. The motivation for this huge refactoring was the CSV importer. While writing it, I did realise our Graph API was very weak and didn't allow effective query over the graph. Now, thanks to the new trait and the CSV importer, we can do:

```rust
        let network: Network<f64> = super::import_network(
            csv::ReaderBuilder::new()
                .flexible(true)
                .from_reader(deps_file),
            csv::ReaderBuilder::new()
                .flexible(true)
                .from_reader(meta_file),
            csv::ReaderBuilder::new()
                .flexible(true)
                .from_reader(contrib_file),
            None,
            &mock_ledger,
        )
        .unwrap_or_else(|e| panic!("returned unexpected error: {}", e));

        assert_eq!(
            network.lookup_node_metadata(&String::from("foo")),
            Some(&ArtifactType::Project {
                osrank: Zero::zero()
            }),
        );

        assert_eq!(
            network.lookup_edge_metadata(&0),
            Some(&DependencyType::Influence(0.8)),
        )
```

I.e. we can now lookup a node via a "userland" notion of `Id`, and ditto for an edge. Under the hood, we keep track of the <userland, graph_id> mapping, so that we can always efficiently index the graph.

The `Graph` trait gets a bit more complicated and it uses some Cthulhu associated types, but it's now quite lean: we have only to define what's an `Edge` and what's a `Node` and the underlying `GraphObject` does the heavy lifting in describing objects which has an `id` and `metadata`. I think the end result is quite ergonomic user-side although now it's a bit trickier to code things library side.

A special mention goes to `algorithm.rs` and its functions: due to the fact we are doing `f64` arithmetic inside `rank_network` and `random_walk`, I had to use two callbacks to actually instruct the algorithms how to get a weight and how to update the metadata given an `Osrank`. Not sure if there is a better approach, but this works for now.



