### PR TITLE
Fix rank_network implementation

### DIFF
--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -102,10 +102,10 @@ where
     for node_idx in network_view.node_ids() {
         let total_walks = random_walks.len();
         let node_visits = &random_walks.count_visits(node_idx);
-        let rank = Fraction::from(ledger_view.get_damping_factors().project)
+        let rank = Fraction::from(1.0 - ledger_view.get_damping_factors().project)
             * Osrank::new(
                 *node_visits as u32,
-                (total_walks * network_view.node_ids().count()) as u32,
+                total_walks as u32,
             );
 
         network_view.update_node_metadata(


### PR DESCRIPTION
This fixes 2 problems:

- `total_walks` already includes all walks for all nodes (ie `nR`) so it shouldn't be multiplied again by the number of vertices
- I believe there is an error in the oscoin white paper. It defines `1 − ε_project` as the probability that the random walks terminates (this also goes along with some definitions of damping factors). The paper from which the rank formula is taken ([incremental PageRank](http://snap.stanford.edu/class/cs224w-readings/bahmani10pagerank.pdf)), defines it the other way around though, so that the resulting formula should be `W_x * (1 - ε_project) / nR` instead of `W_x * ε_project / nR`.