### PR TITLE
CI: Put CARGO_HOME on /cache volume

### DIFF
--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -13,6 +13,6 @@ RUN cargo install sccache \
     && rm -rf /usr/local/cargo/registry \
     && rm /usr/local/cargo/.package-cache
 
-# Setup defaults for sccache
+# Setup defaults for caching
 VOLUME /cache
-ENV SCCACHE_DIR=/cache/sccache RUSTC_WRAPPER=sccache
+ENV SCCACHE_DIR=/cache/sccache RUSTC_WRAPPER=sccache CARGO_HOME=/cache/cargo


### PR DESCRIPTION
This will persist the crates.io index and any source dependencies across builds.

Also allows mounting the rootfs read-only.