### PR TITLE
Add new CI step for bench

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -1,5 +1,12 @@
 steps:
-  - command: 'cargo test --features build-binary --all'
+  - label: "Tests"
+    command: 'cargo test --features build-binary --all'
+    env:
+      DOCKER_IMAGE: "gcr.io/opensourcecoin/osrank-build:rustc-1.36.0"
+    agents:
+      docker: "true"
+  - label: "Compile benchmarks (no-run)"
+    command: 'cargo bench --no-run'
     env:
       DOCKER_IMAGE: "gcr.io/opensourcecoin/osrank-build:rustc-1.36.0"
     agents:


### PR DESCRIPTION
This PR aims to add a new step to CI, so that we build (but don't run) benchmarks, so that we can catch build regressions (it happens to me twice, already!).