### PR TITLE
Fix Rust 1.37 warnings

### DIFF
--- a/benches/osrank_naive.rs
+++ b/benches/osrank_naive.rs
@@ -118,7 +118,7 @@ fn run_osrank_naive(mut network: &mut Network<f64>, iter: u32, initial_seed: [u8
 fn run_random_walk(network: &Network<f64>, iter: u32, initial_seed: [u8; 16]) {
     let mut mock_ledger = MockLedger::default();
     mock_ledger.set_random_walks_num(iter);
-    let get_weight: Box<Fn(&<Dependency<usize, f64> as GraphObject>::Metadata) -> f64> =
+    let get_weight: Box<dyn Fn(&<Dependency<usize, f64> as GraphObject>::Metadata) -> f64> =
         Box::new(|m: &DependencyType<f64>| *m.get_weight());
     random_walk::<MockLedger, MockNetwork, XorShiftRng>(
         None,
@@ -168,9 +168,9 @@ fn bench_rank_network(c: &mut Criterion) {
     let mut network = construct_network(1_000, 10_000);
     let mut mock_ledger = MockLedger::default();
     mock_ledger.set_random_walks_num(1);
-    let get_weight: Box<Fn(&<Dependency<usize, f64> as GraphObject>::Metadata) -> f64> =
+    let get_weight: Box<dyn Fn(&<Dependency<usize, f64> as GraphObject>::Metadata) -> f64> =
         Box::new(|m: &DependencyType<f64>| *m.get_weight());
-    let set_osrank: Box<(Fn(&Artifact<String>, Osrank) -> ArtifactType)> =
+    let set_osrank: Box<dyn Fn(&Artifact<String>, Osrank) -> ArtifactType> =
         Box::new(|node: &Artifact<String>, rank| match node.get_metadata() {
             ArtifactType::Project { osrank: _ } => ArtifactType::Project { osrank: rank },
             ArtifactType::Account { osrank: _ } => ArtifactType::Account { osrank: rank },

--- a/bin/main.rs
+++ b/bin/main.rs
@@ -4,7 +4,7 @@ use std::fs::File;
 
 use self::osrank::importers::gephi_json::{from_gephi_json, GephiEdge, GephiNode};
 
-fn main() -> Result<(), Box<std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cargo_nodes = File::open("data/cargo_nodes.json")?;
     let cargo_edges = File::open("data/cargo_edges.json")?;
     let gephi_nodes: Vec<GephiNode> = serde_json::from_reader(cargo_nodes)?;

--- a/bin/source_contributions.rs
+++ b/bin/source_contributions.rs
@@ -358,14 +358,14 @@ fn is_maintainer(owner: &str, stat: &GithubContribution, stats_len: usize) -> bo
     stat.author.login == owner || { stat.total > 50 } || stats_len as u32 == 1
 }
 
-fn by_platform<'a>(platform: &'a str) -> Box<FnMut(&StringRecord) -> bool + 'a> {
+fn by_platform<'a>(platform: &'a str) -> Box<dyn FnMut(&StringRecord) -> bool + 'a> {
     Box::new(move |e| e[1] == *platform)
 }
 
 // Returns false if the user didn't ask to resume the process from a particular
 // project URL. If the user supplied a project, it skips StringRecord entries
 // until it matches the input URL.
-fn resumes<'a>(resume_from: Option<&'a str>) -> Box<FnMut(&StringRecord) -> bool + 'a> {
+fn resumes<'a>(resume_from: Option<&'a str>) -> Box<dyn FnMut(&StringRecord) -> bool + 'a> {
     Box::new(move |e| match resume_from {
         None => false,
         Some(repo_url) => Some(repo_url) != e.get(9),

--- a/bin/source_dependencies.rs
+++ b/bin/source_dependencies.rs
@@ -115,7 +115,7 @@ fn extract_metadata(
     Ok(())
 }
 
-fn by_platform<'a>(platform: &'a str) -> Box<FnMut(&StringRecord) -> bool + 'a> {
+fn by_platform<'a>(platform: &'a str) -> Box<dyn FnMut(&StringRecord) -> bool + 'a> {
     Box::new(move |e| e[1] == *platform)
 }
 

--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -27,7 +27,7 @@ where
     I: Eq + Hash,
 {
     network_view: G,
-    walks: RandomWalks<I>,
+    pub walks: RandomWalks<I>,
 }
 
 fn walks<'a, L, G: 'a, RNG>(
@@ -35,7 +35,7 @@ fn walks<'a, L, G: 'a, RNG>(
     network: &G,
     ledger_view: &L,
     mut rng: RNG,
-    get_weight: &Box<Fn(&<G::Edge as GraphObject>::Metadata) -> f64>,
+    get_weight: &dyn Fn(&<G::Edge as GraphObject>::Metadata) -> f64,
 ) -> RandomWalks<Id<G::Node>>
 where
     L: LedgerView,
@@ -82,7 +82,7 @@ pub fn random_walk<L, G, RNG>(
     network: &G,
     ledger_view: &L,
     rng: RNG,
-    get_weight: &Box<Fn(&<G::Edge as GraphObject>::Metadata) -> f64>,
+    get_weight: &dyn Fn(&<G::Edge as GraphObject>::Metadata) -> f64,
 ) -> Result<WalkResult<G, <G::Node as GraphObject>::Id>, OsrankError>
 where
     L: LedgerView,
@@ -92,7 +92,7 @@ where
 {
     match seed_set {
         Some(seeds) => {
-            let walks = walks(seeds.into_iter(), network, ledger_view, rng, get_weight);
+            let walks = walks(seeds.seedset_iter(), network, ledger_view, rng, get_weight);
             let mut trusted_node_ids: Vec<&Id<G::Node>> = Vec::new();
             for node in network.nodes() {
                 if rank_node::<L, G>(&walks, node.id().clone(), ledger_view) > Osrank::zero() {
@@ -125,8 +125,8 @@ pub fn osrank_naive<L, G, RNG>(
     network: &mut G,
     ledger_view: &L,
     initial_seed: <RNG as SeedableRng>::Seed,
-    get_weight: Box<Fn(&<G::Edge as GraphObject>::Metadata) -> f64>,
-    from_osrank: Box<(Fn(&G::Node, Osrank) -> Metadata<G::Node>)>,
+    get_weight: Box<dyn Fn(&<G::Edge as GraphObject>::Metadata) -> f64>,
+    from_osrank: Box<dyn Fn(&G::Node, Osrank) -> Metadata<G::Node>>,
 ) -> Result<(), OsrankError>
 where
     L: LedgerView,
@@ -198,7 +198,7 @@ pub fn rank_network<'a, L, G: 'a>(
     random_walks: &RandomWalks<Id<G::Node>>,
     network_view: &'a mut G,
     ledger_view: &L,
-    from_osrank: &Box<(Fn(&G::Node, Osrank) -> Metadata<G::Node>)>,
+    from_osrank: &dyn Fn(&G::Node, Osrank) -> Metadata<G::Node>,
 ) -> Result<(), OsrankError>
 where
     L: LedgerView,

--- a/src/protocol_traits/graph.rs
+++ b/src/protocol_traits/graph.rs
@@ -166,7 +166,7 @@ pub type EdgeReferences<'a, N, E> = Vec<EdgeReference<'a, N, E>>;
 
 pub struct Nodes<'a, N: 'a> {
     pub range: Range<usize>,
-    pub to_node_id: Box<(Fn(usize) -> &'a N) + 'a>,
+    pub to_node_id: Box<dyn (Fn(usize) -> &'a N) + 'a>,
 }
 
 pub struct NodesMut<'a, N: 'a> {

--- a/src/types/network.rs
+++ b/src/types/network.rs
@@ -7,7 +7,6 @@ extern crate petgraph;
 
 use num_traits::Zero;
 use std::collections::HashMap;
-use std::collections::HashSet;
 use std::fmt;
 use std::fs::OpenOptions;
 use std::io::Write;

--- a/src/types/walk.rs
+++ b/src/types/walk.rs
@@ -169,7 +169,7 @@ impl<I> SeedSet<I> {
         self.trusted_nodes.is_empty()
     }
 
-    pub fn into_iter(&self) -> SeedSetIter<I> {
+    pub fn seedset_iter(&self) -> SeedSetIter<I> {
         SeedSetIter {
             range: 0..self.trusted_nodes.len(),
             inner: &self.trusted_nodes,


### PR DESCRIPTION
This quick PR fixes a number of compilation warnings (and `cargo clippy` lints) which appeared after I did upgrade my `rustc` compiler to `1.37`.