### PR TITLE
Use a Docker image specified by its SHA

### DIFF
--- a/.buildkite/coverage.yaml
+++ b/.buildkite/coverage.yaml
@@ -1,7 +1,6 @@
 steps:
   - label: 'Code Coverage (experimental)'
     command: |
-        find . -name "*.gcda" -print0 | xargs -0 rm;
         RUSTC_WRAPPER="" RUSTFLAGS="-Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off" cargo cov test --lib;
         zip -0 ccov.zip `find . \( -name "osrank*.gc*" \) -print`;
         grcov ccov.zip -s . -t lcov > lcov0.info;
@@ -9,6 +8,6 @@ steps:
         lcov --remove lcov1.info "*registry*" -o lcov.info;
         bash <(curl -s https://codecov.io/bash) -f lcov.info || echo "Codecov did not collect coverage reports"
     env:
-      DOCKER_IMAGE: "gcr.io/opensourcecoin/osrank-build@sha256:3839633b3f00a9852bd3b4256bf9853e9cea2553ca62f6a602c4d7fa7cd9a404"
+      DOCKER_IMAGE: "gcr.io/opensourcecoin/osrank-build@sha256:00e4c02a7391457031c2f3d3a548e92aa44fd2341de08918968040fe9f2793eb"
     agents:
       docker: "true"

--- a/.buildkite/coverage.yaml
+++ b/.buildkite/coverage.yaml
@@ -1,12 +1,14 @@
 steps:
   - label: 'Code Coverage (experimental)'
     command: |
-        RUSTC_WRAPPER="" RUSTFLAGS="-Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off" cargo cov test --all;
+        find . -name "*.gcda" -print0 | xargs -0 rm;
+        RUSTC_WRAPPER="" RUSTFLAGS="-Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off" cargo cov test --lib;
         zip -0 ccov.zip `find . \( -name "osrank*.gc*" \) -print`;
         grcov ccov.zip -s . -t lcov > lcov0.info;
         lcov --remove lcov0.info "*rustc*" -o lcov1.info;
         lcov --remove lcov1.info "*registry*" -o lcov.info;
+        bash <(curl -s https://codecov.io/bash) -f lcov.info || echo "Codecov did not collect coverage reports"
     env:
-      DOCKER_IMAGE: "gcr.io/opensourcecoin/osrank-build@sha256:630f3d148d1144e79157bee1685ff3130b6cd620cb77300916c691fcbe29e696"
+      DOCKER_IMAGE: "gcr.io/opensourcecoin/osrank-build@sha256:3839633b3f00a9852bd3b4256bf9853e9cea2553ca62f6a602c4d7fa7cd9a404"
     agents:
       docker: "true"

--- a/.buildkite/coverage.yaml
+++ b/.buildkite/coverage.yaml
@@ -1,0 +1,12 @@
+steps:
+  - label: 'Code Coverage (experimental)'
+    command: |
+        RUSTC_WRAPPER="" RUSTFLAGS="-Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off" cargo cov test --all;
+        zip -0 ccov.zip `find . \( -name "osrank*.gc*" \) -print`;
+        grcov ccov.zip -s . -t lcov > lcov0.info;
+        lcov --remove lcov0.info "*rustc*" -o lcov1.info;
+        lcov --remove lcov1.info "*registry*" -o lcov.info;
+    env:
+      DOCKER_IMAGE: "gcr.io/opensourcecoin/osrank-build@sha256:630f3d148d1144e79157bee1685ff3130b6cd620cb77300916c691fcbe29e696"
+    agents:
+      docker: "true"

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -12,18 +12,3 @@ steps:
       DOCKER_IMAGE: "gcr.io/opensourcecoin/osrank-build@sha256:630f3d148d1144e79157bee1685ff3130b6cd620cb77300916c691fcbe29e696"
     agents:
       docker: "true"
-
-  - label: 'Code Coverage (experimental)'
-    command: |
-        RUSTFLAGS="-Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off" cargo cov test --all;
-        zip -0 ccov.zip `find . \( -name "osrank*.gc*" \) -print`;
-        grcov ccov.zip -s . -t lcov > lcov0.info;
-        lcov --remove lcov0.info "*rustc*" -o lcov1.info;
-        lcov --remove lcov1.info "*registry*" -o lcov.info;
-    env:
-      DOCKER_IMAGE: "gcr.io/opensourcecoin/osrank-build@sha256:630f3d148d1144e79157bee1685ff3130b6cd620cb77300916c691fcbe29e696"
-    agents:
-      docker: "true"
-    soft_fail:
-        - exit_status: 1
-        - exit_status: 127

--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -2,14 +2,14 @@ steps:
   - label: "Tests"
     command: 'cargo test --features build-binary --all'
     env:
-      DOCKER_IMAGE: "gcr.io/opensourcecoin/osrank-build:rustc-1.37.0"
+      DOCKER_IMAGE: "gcr.io/opensourcecoin/osrank-build@sha256:630f3d148d1144e79157bee1685ff3130b6cd620cb77300916c691fcbe29e696"
     agents:
       docker: "true"
 
   - label: "Compile benchmarks (no-run)"
     command: 'cargo bench --no-run'
     env:
-      DOCKER_IMAGE: "gcr.io/opensourcecoin/osrank-build:rustc-1.37.0"
+      DOCKER_IMAGE: "gcr.io/opensourcecoin/osrank-build@sha256:630f3d148d1144e79157bee1685ff3130b6cd620cb77300916c691fcbe29e696"
     agents:
       docker: "true"
 
@@ -21,7 +21,7 @@ steps:
         lcov --remove lcov0.info "*rustc*" -o lcov1.info;
         lcov --remove lcov1.info "*registry*" -o lcov.info;
     env:
-      DOCKER_IMAGE: "gcr.io/opensourcecoin/osrank-build:rustc-1.37.0"
+      DOCKER_IMAGE: "gcr.io/opensourcecoin/osrank-build@sha256:630f3d148d1144e79157bee1685ff3130b6cd620cb77300916c691fcbe29e696"
     agents:
       docker: "true"
     soft_fail:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,26 @@
+codecov:
+  notify:
+    require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project: yes
+    patch: yes
+    changes: no
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "header, diff"
+  behavior: default
+  require_changes: no

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update \
         llvm-dev \
         libclang-dev \
         lcov \
+        curl \
     && apt-get autoremove \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update \
         zip \
         llvm-dev \
         libclang-dev \
+        lcov \
     && apt-get autoremove \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker/build/Dockerfile
+++ b/docker/build/Dockerfile
@@ -11,14 +11,14 @@ RUN apt-get update \
     && apt-get autoremove \
     && rm -rf /var/lib/apt/lists/*
 
-# Install sccache
+# Install sccache and the rest of the code coverage tools.
+# The second dependency is technically not required but it automate the 
+# generation of .gc* files.
 RUN cargo install sccache \
     && rm -rf /usr/local/cargo/registry \
-    && rm /usr/local/cargo/.package-cache
-
-# Install grcov, for code coverage. The second dependency is technically
-# not required but it automate the generation of .gc* files.
-RUN cargo install grcov && cargo install cargo-cov
+    && rm /usr/local/cargo/.package-cache \
+    && cargo install grcov \
+    && cargo install cargo-cov
 
 # Setup defaults for caching
 VOLUME /cache


### PR DESCRIPTION
This PR merges the two rust-specific `RUST` in the `Dockerfile`, although this didn't come with a less beefy image. I did try to use `docker build --squash` and also the now-seemingly-broken tool `docker-squash`, but couldn't do better than 1.74GB, oh well.

I have also switched to be using the newly-pushed Docker image as identified by its SHA, to have precise control over it.