### PR TITLE
Gexf exporter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -366,8 +366,11 @@ name = "env_logger"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
+ "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -525,6 +528,14 @@ dependencies = [
 name = "httparse"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "humantime"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "hyper"
@@ -934,11 +945,13 @@ dependencies = [
  "criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "csv 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "fraction 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "ndarray 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "oscoin-graph-api 0.1.0 (git+https://github.com/oscoin/graph-api.git?rev=c8eed614f0d8d4f0ab265416f8caf2f4c60a1560)",
@@ -1081,6 +1094,11 @@ dependencies = [
  "regex 1.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "quickcheck"
@@ -1588,6 +1606,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "wincolor 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "termion"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1912,6 +1938,15 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "wincolor"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ws2_32-sys"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1983,6 +2018,7 @@ dependencies = [
 "checksum http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "eed324f0f0daf6ec10c474f150505af2c143f251722bf9dbd1261bd1f2ee2c1a"
 "checksum http-body 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6741c859c1b2463a423a1dbce98d418e6c3c3fc720fb0d45528657320920292d"
 "checksum httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
+"checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
 "checksum hyper 0.12.31 (registry+https://github.com/rust-lang/crates.io-index)" = "6481fff8269772d4463253ca83c788104a7305cb3fb9136bc651a6211e46e03f"
 "checksum hyper-tls 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3a800d6aa50af4b5850b2b0f659625ce9504df908e9733b635720483be26174f"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
@@ -2041,6 +2077,7 @@ dependencies = [
 "checksum pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3f81e1644e1b54f5a68959a29aa86cde704219254669da328ecfdf6a1f09d427"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum publicsuffix 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5afecba86dcf1e4fd610246f89899d1924fe12e1e89f555eb7c7f710f3c5ad1d"
+"checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quickcheck 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d5ca504a2fdaa08d3517f442fbbba91ac24d1ec4c51ea68688a038765e3b2662"
 "checksum quickcheck_macros 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d7dfc1c4a1e048f5cc7d36a4c4118dfcf31d217c79f4b9a61bad65d68185752c"
 "checksum quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "faf4799c5d274f3868a4aae320a0a182cbd2baee377b378f080e16a23e9d80db"
@@ -2098,6 +2135,7 @@ dependencies = [
 "checksum syn 0.15.39 (registry+https://github.com/rust-lang/crates.io-index)" = "b4d960b829a55e56db167e861ddb43602c003c7be0bee1d345021703fac2fb7c"
 "checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
+"checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
 "checksum termion 1.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6a8fb22f7cde82c8220e5aeacb3258ed7ce996142c77cba193f203515e26c330"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
@@ -2136,4 +2174,5 @@ dependencies = [
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7168bab6e1daee33b4557efd0e95d5ca70a03706d39fa5f3fe7a236f584b03c9"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+"checksum wincolor 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "96f5016b18804d24db43cebf3c77269e7569b8954a8464501c216cc5e070eaa9"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ required-features = ["build-binary"]
 
 [features]
 
-build-binary = ["reqwest", "clap", "failure", "failure_derive"]
+build-binary = ["reqwest", "clap", "failure", "failure_derive", "env_logger"]
 
 [dependencies]
 
@@ -51,6 +51,7 @@ num-traits = "^0.2"
 derive_more = "^0.13"
 itertools = "^0.8.0"
 fnv = "^1.0.3"
+log = "0.4.0"
 
 # We need to lock quickcheck to the same version of rand used by this crate.
 quickcheck = "=0.9"
@@ -78,6 +79,7 @@ reqwest = { version = "^0.9", optional = true }
 clap = { version = "^2.33", optional = true }
 failure = { version = "0.1.5", optional = true}
 failure_derive = { version = "0.1.5", optional = true}
+env_logger = { version = "0.6.2", optional = true}
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,11 @@ path = "bin/adjacency_matrix.rs"
 bench = false
 required-features = ["build-binary"]
 
+[[bin]]
+name = "osrank-export-to-gephi"
+path = "bin/export_gephi.rs"
+required-features = ["build-binary"]
+
 [features]
 
 build-binary = ["reqwest", "clap", "failure", "failure_derive"]

--- a/bin/adjacency_matrix.rs
+++ b/bin/adjacency_matrix.rs
@@ -16,7 +16,7 @@ use osrank::adjacency::new_network_matrix;
 use osrank::collections::{Rank, WithLabels};
 use osrank::importers::csv::{
     new_contribution_adjacency_matrix, new_dependency_adjacency_matrix, ContribRow,
-    ContributionsMetadata, CsvImportError, DepMetaRow, DependenciesMetadata,
+    ContributionsMetadata, CsvImportError, DepMetaRow, DependenciesMetadata, DisplayAsF64,
 };
 use osrank::linalg::{transpose_storage, DenseMatrix, SparseMatrix};
 use osrank::types::{HyperParams, Weight};
@@ -28,26 +28,6 @@ use num_traits::{Num, One, Signed, Zero};
 use std::fs::{File, OpenOptions};
 use std::io::Write;
 use std::rc::Rc;
-
-//
-// Utility Traits
-//
-
-pub trait DisplayAsF64 {
-    fn to_f64(self) -> f64;
-}
-
-impl DisplayAsF64 for f64 {
-    fn to_f64(self: f64) -> f64 {
-        self
-    }
-}
-
-impl DisplayAsF64 for Weight {
-    fn to_f64(self: Weight) -> f64 {
-        self.as_f64().unwrap()
-    }
-}
 
 //
 // Functions
@@ -147,41 +127,6 @@ where
     }
 
     dense
-}
-
-pub fn debug_sparse_matrix_to_csv<N>(
-    matrix: &CsMat<N>,
-    out_path: &str,
-) -> Result<(), CsvImportError>
-where
-    N: DisplayAsF64 + Zero + Clone + Copy,
-{
-    debug_dense_matrix_to_csv(&matrix.to_dense(), out_path)
-}
-
-pub fn debug_dense_matrix_to_csv<N>(
-    matrix: &DenseMatrix<N>,
-    out_path: &str,
-) -> Result<(), CsvImportError>
-where
-    N: DisplayAsF64 + Zero + Clone + Copy,
-{
-    let mut output_csv = OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(out_path)?;
-
-    for row in matrix.genrows() {
-        if let Some((last, els)) = row.as_slice().and_then(|e| e.split_last()) {
-            for cell in els {
-                output_csv.write_all(format!("{},", cell.to_f64()).as_str().as_bytes())?;
-            }
-            output_csv.write_all(format!("{}", last.to_f64()).as_str().as_bytes())?;
-        }
-        output_csv.write_all(b"\n")?;
-    }
-
-    Ok(())
 }
 
 fn debug_pagerank_to_csv(rank: &Rank<f64>, out_path: &str) -> Result<(), CsvImportError> {

--- a/bin/export_gephi.rs
+++ b/bin/export_gephi.rs
@@ -108,7 +108,7 @@ fn main() -> Result<(), AppError> {
         unmock: OsrankNaiveAlgorithm::default(),
     };
     let mut ctx = OsrankNaiveMockContext::default();
-    ctx.ledger_view.set_random_walks_num(5);
+    ctx.ledger_view.set_random_walks_num(1);
 
     let mut network = import_network::<MockNetwork, MockLedger, File>(
         csv::Reader::from_reader(deps_csv_file),

--- a/bin/export_gephi.rs
+++ b/bin/export_gephi.rs
@@ -9,7 +9,7 @@ extern crate clap;
 
 use clap::{App, Arg};
 
-use osrank::exporters::gexf;
+use osrank::exporters::{gexf, graphml};
 use osrank::importers::csv::{import_network, CsvImportError};
 use osrank::protocol_traits::ledger::MockLedger;
 use osrank::types::mock::MockNetwork;
@@ -20,7 +20,8 @@ use std::path::Path;
 #[derive(Debug)]
 enum AppError {
     ImportError(CsvImportError),
-    ExportError(gexf::ExportError),
+    GexfExportError(gexf::ExportError),
+    GraphMlExportError(graphml::ExportError),
 }
 
 impl From<CsvImportError> for AppError {
@@ -31,7 +32,13 @@ impl From<CsvImportError> for AppError {
 
 impl From<gexf::ExportError> for AppError {
     fn from(err: gexf::ExportError) -> AppError {
-        AppError::ExportError(err)
+        AppError::GexfExportError(err)
+    }
+}
+
+impl From<graphml::ExportError> for AppError {
+    fn from(err: graphml::ExportError) -> AppError {
+        AppError::GraphMlExportError(err)
     }
 }
 
@@ -98,9 +105,11 @@ fn main() -> Result<(), AppError> {
         &mock_ledger,
     )?;
 
-    debug!("Exporting the network...");
+    debug!("Exporting the network to .gexf ...");
+    gexf::export_graph(&network, &Path::new(&(out.to_owned() + ".gexf")))?;
 
-    gexf::export_graph(&network, &Path::new(out))?;
+    debug!("Exporting the network to .graphml ...");
+    graphml::export_graph(&network, &Path::new(&(out.to_owned() + ".graphml")))?;
 
     debug!("Done.");
 

--- a/bin/export_gephi.rs
+++ b/bin/export_gephi.rs
@@ -1,0 +1,75 @@
+#![allow(unknown_lints)]
+#![warn(clippy::all)]
+
+extern crate clap;
+
+use clap::{App, Arg};
+
+use osrank::exporters::gexf;
+use osrank::importers::csv::import_network;
+use osrank::protocol_traits::ledger::MockLedger;
+use osrank::types::mock::MockNetwork;
+
+use std::fs::File;
+use std::path::Path;
+
+fn main() -> Result<(), CsvImportError> {
+    let matches = App::new("Export a Graph into a GEFX xml.")
+        .arg(
+            Arg::with_name("dependencies")
+                .long("deps")
+                .help("Path to the <platform>_dependencies.csv file")
+                .takes_value(true)
+                .required(true),
+        )
+        .arg(
+            Arg::with_name("dependencies-with-metadata")
+                .long("deps-meta")
+                .help("Path to the <platform>_dependencies_meta.csv file")
+                .takes_value(true)
+                .required(true),
+        )
+        .arg(
+            Arg::with_name("contributions")
+                .long("contribs")
+                .help("Path to the <platform>_contributions.csv file")
+                .takes_value(true)
+                .required(true),
+        )
+        .arg(
+            Arg::with_name("output-path")
+                .short("o")
+                .help("Path to the output .gexf file")
+                .takes_value(true)
+                .required(true),
+        )
+        .get_matches();
+
+    let deps = matches
+        .value_of("dependencies")
+        .expect("dependencies csv file not given.");
+    let deps_meta = matches
+        .value_of("dependencies-with-metadata")
+        .expect("dependencies with metadata csv file not given.");
+    let contribs = matches
+        .value_of("contributions")
+        .expect("contributions csv file not given.");
+    let out = matches
+        .value_of("output-path")
+        .expect("output csv file not specified.");
+
+    let mut deps_csv_file = File::open(deps).unwrap();
+    let mut deps_meta_csv_file = File::open(deps_meta).unwrap();
+    let mut contribs_csv_file = File::open(contribs).unwrap();
+
+    let mock_ledger = MockLedger::default();
+    let network = import_network::<MockNetwork, MockLedger, File>(
+        csv::Reader::from_reader(deps_csv_file),
+        csv::Reader::from_reader(deps_meta_csv_file),
+        csv::Reader::from_reader(contribs_csv_file),
+        None,
+        &mock_ledger,
+    );
+
+    gexf::export_graph(&network, &Path::new(out));
+}

--- a/src/exporters/gexf.rs
+++ b/src/exporters/gexf.rs
@@ -145,7 +145,7 @@ where
             node.id()
                 .clone()
                 .try_into()
-                .unwrap_or(String::from("Unlabeled node")),
+                .unwrap_or_else(|_| String::from("Unlabeled node")),
         ),
         attrs: Vec::new(),
     };

--- a/src/exporters/gexf.rs
+++ b/src/exporters/gexf.rs
@@ -1,0 +1,163 @@
+#![allow(unknown_lints)]
+#![warn(clippy::all)]
+
+use crate::protocol_traits::graph::{EdgeReference, Graph, GraphObject};
+use crate::types::network::Artifact;
+
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::path::Path;
+
+static GEXF_META: &str = r###"
+<?xml version="1.0" encoding="UTF-8"?>
+<gexf xmlns="http://www.gexf.net/1.2draft" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gexf.net/1.2draft http://www.gexf.net/1.2draft/gexf.xsd" version="1.2">
+    <meta lastmodifieddate="2009-03-20">
+        <creator>Gephi.org</creator>
+        <description>A Web network</description>
+    </meta>
+"###;
+
+static GEXF_FOOTER: &str = "</gexf>";
+
+pub enum ExportError {
+    IOError(std::io::Error),
+}
+
+impl From<std::io::Error> for ExportError {
+    fn from(err: std::io::Error) -> ExportError {
+        ExportError::IOError(err)
+    }
+}
+
+pub trait IntoGefxXml {
+    fn render(&self) -> String;
+}
+
+struct GexfAttribute<K, V> {
+    attr_for: K,
+    attr_value: V,
+}
+
+impl IntoGefxXml for String {
+    fn render(&self) -> String {
+        self.clone()
+    }
+}
+
+impl<K, V> IntoGefxXml for GexfAttribute<K, V>
+where
+    K: IntoGefxXml,
+    V: IntoGefxXml,
+{
+    fn render(&self) -> String {
+        format!(
+            "<attvalue for=\"{}\" value=\"{}\"/>",
+            self.attr_for.render(),
+            self.attr_value.render()
+        )
+    }
+}
+
+impl<V> IntoGefxXml for Option<V>
+where
+    V: IntoGefxXml,
+{
+    fn render(&self) -> String {
+        match self {
+            None => String::new(),
+            Some(v) => v.render(),
+        }
+    }
+}
+
+struct GexfNode<I> {
+    id: I,
+    label: Option<String>,
+    attrs: Vec<GexfAttribute<String, String>>,
+}
+
+impl<I> IntoGefxXml for GexfNode<I>
+where
+    I: IntoGefxXml,
+{
+    fn render(&self) -> String {
+        let mut values = String::new();
+
+        for a in &self.attrs {
+            values.push_str(a.render().as_str())
+        }
+
+        format!(
+            "<node id=\"{}\" label=\"{}\">\\n<attvalues>{}</attvalues>\\n</node>",
+            self.id.render(),
+            self.label.render(),
+            values
+        )
+    }
+}
+
+/// Converts a `Graph::Node` into some GEXF tags.
+fn write_node<N>(node: &N, out: &mut File) -> Result<(), ExportError>
+where
+    N: GraphObject,
+    N::Id: IntoGefxXml + Clone,
+{
+    let gexf_node = GexfNode {
+        id: node.id().clone(),
+        label: None,
+        attrs: Vec::new(),
+    };
+
+    out.write_all(gexf_node.render().as_bytes())?;
+    Ok(())
+}
+
+/// Converts a `Graph::Edge` into some GEXF tags.
+fn write_edge<N, E>(edge: &EdgeReference<N, E>, out: &mut File) -> Result<(), ExportError>
+where
+    E: IntoGefxXml + Clone,
+{
+    Ok(())
+}
+
+/// Converts the `Graph` into some GEXF tags.
+fn write_graph<G>(g: &G, out: &mut File) -> Result<(), ExportError>
+where
+    G: Graph,
+    <G::Node as GraphObject>::Id: IntoGefxXml + Clone,
+    <G::Edge as GraphObject>::Id: IntoGefxXml + Clone,
+{
+    let mut all_edges = Vec::new();
+
+    out.write_all("<nodes>".as_bytes())?;
+
+    for n in g.nodes() {
+        write_node(n, out)?;
+        all_edges.extend(g.neighbours(n.id()))
+    }
+
+    out.write_all("</nodes>\\n<edges>".as_bytes())?;
+
+    for e in &all_edges {
+        write_edge(e, out)?;
+    }
+
+    out.write_all("</edges>".as_bytes())?;
+
+    Ok(())
+}
+
+pub fn export_graph<G>(g: &G, out: &Path) -> Result<(), ExportError>
+where
+    G: Graph,
+    <G::Node as GraphObject>::Id: IntoGefxXml + Clone,
+    <G::Edge as GraphObject>::Id: IntoGefxXml + Clone,
+{
+    let mut out_file = OpenOptions::new().write(true).create_new(true).open(out)?;
+
+    out_file.write_all(GEXF_META.as_bytes())?;
+    write_graph(g, &mut out_file)?;
+    out_file.write_all(GEXF_FOOTER.as_bytes())?;
+
+    Ok(())
+}

--- a/src/exporters/mod.rs
+++ b/src/exporters/mod.rs
@@ -1,3 +1,5 @@
 pub mod dot;
 /// Exports a Graph into GEXF (Gephi Exchange Format).
 pub mod gexf;
+/// Exports a Graph into GraphML.
+pub mod graphml;

--- a/src/exporters/mod.rs
+++ b/src/exporters/mod.rs
@@ -1,1 +1,3 @@
 pub mod dot;
+/// Exports a Graph into GEXF (Gephi Exchange Format).
+pub mod gexf;


### PR DESCRIPTION
This is the first iteration for #51.

While the exporter technically work, it its current state is not very useful as the generate graph is huge, and it's the "un-normalised" one. One might argue this is orthogonal to the exporter itself, and I'd agree with that.

Another thing which is not possible to do is to give nodes space coordinates, so usually once the `.gexf` is exported is necessary to open it with an external tool (like the Gephi's Desktop app) and force a layout (e.g. Atlas). Last but not least, at the moment the label for each node is simply "test" and there are no weights on the edges and no `osrank` property for nodes. 