### PR TITLE
Add traits to improve API readability

### DIFF
--- a/src/protocol_traits/graph.rs
+++ b/src/protocol_traits/graph.rs
@@ -2,6 +2,7 @@
 #![warn(clippy::all)]
 
 extern crate oscoin_graph_api as oscoin;
+extern crate petgraph;
 extern crate rand;
 
 /// This is a compatibility-shim trait for things that the "official"
@@ -26,4 +27,33 @@ pub trait GraphExtras: oscoin::Graph + oscoin::GraphDataWriter + oscoin::GraphWr
 
     /// Creates a subgraph of on the nodes of `sub_nodes` of `self`.
     fn subgraph_by_nodes(&self, sub_nodes: Vec<&oscoin::Id<Self::Node>>) -> Self;
+}
+
+/// Little shim that rename some petgraph edge-related methods to be less
+/// confusing, giving osrank's overloaded dictionary of names.
+pub trait PetgraphEdgeAdaptor<'a, EdgeData: 'a> {
+    fn petgraph_edge_data(&self) -> &'a EdgeData;
+}
+
+impl<'a, E: 'a, Ix: 'a> PetgraphEdgeAdaptor<'a, E> for petgraph::graph::EdgeReference<'a, E, Ix>
+where
+    Ix: petgraph::graph::IndexType,
+{
+    fn petgraph_edge_data(&self) -> &'a E {
+        self.weight()
+    }
+}
+
+/// Like `PetgraphEdgeAdaptor`, but that works on nodes.
+pub trait PetgraphNodeAdaptor<NodeData> {
+    fn petgraph_node_data(&self) -> &NodeData;
+}
+
+impl<N, Ix> PetgraphNodeAdaptor<N> for petgraph::graph::Node<N, Ix>
+where
+    Ix: petgraph::graph::IndexType,
+{
+    fn petgraph_node_data(&self) -> &N {
+        &self.weight
+    }
 }

--- a/src/types/mock.rs
+++ b/src/types/mock.rs
@@ -17,7 +17,7 @@ struct ArbitraryEdge<'a> {
     target: &'a String,
     id: usize,
     weight: f64,
-    metadata: DependencyType<f64>,
+    data: DependencyType<f64>,
 }
 
 impl Arbitrary for MockNetwork {
@@ -33,7 +33,7 @@ impl Arbitrary for MockNetwork {
         }
 
         for e in edges {
-            graph.add_edge(e.id, e.source, e.target, e.weight, e.metadata)
+            graph.add_edge(e.id, e.source, e.target, e.weight, e.data)
         }
 
         graph
@@ -85,7 +85,7 @@ fn arbitrary_normalised_edges_from<'a, G: Gen + Rng>(
                         source: &node.id(),
                         target: &nodes[ix].id(),
                         weight: w,
-                        metadata: DependencyType::Influence(w),
+                        data: DependencyType::Influence(w),
                     });
 
                     id_counter += 1;

--- a/src/types/network.rs
+++ b/src/types/network.rs
@@ -14,7 +14,7 @@ use std::io::Write;
 use std::path::Path;
 
 use super::Osrank;
-use crate::protocol_traits::graph::GraphExtras;
+use crate::protocol_traits::graph::{GraphExtras, PetgraphEdgeAdaptor, PetgraphNodeAdaptor};
 use oscoin_graph_api::{
     Data, Edge, EdgeRefs, Edges, Graph, GraphDataWriter, GraphObject, GraphWriter, Id, Node, Nodes,
     NodesMut,
@@ -417,7 +417,7 @@ where
                 .from_graph
                 .raw_nodes()
                 .iter()
-                .map(|n| &n.weight)
+                .map(|n| n.petgraph_node_data())
                 .collect::<Vec<&Self::Node>>()
                 .into_iter(),
         }
@@ -433,7 +433,7 @@ where
                 range: self
                     .from_graph
                     .edges(*nid)
-                    .map(|e| e.weight())
+                    .map(|e| e.petgraph_edge_data())
                     .collect::<Vec<&Self::Edge>>()
                     .into_iter(),
             },
@@ -533,7 +533,12 @@ where
     W: Default + fmt::Display + Clone,
 {
     fn print_nodes(&self) {
-        for arti in self.from_graph.raw_nodes().iter().map(|node| &node.weight) {
+        for arti in self
+            .from_graph
+            .raw_nodes()
+            .iter()
+            .map(|node| node.petgraph_node_data())
+        {
             println!("{}", arti);
         }
     }


### PR DESCRIPTION
This PR adds a bunch of traits which wraps some confusingly-named `petgraph` methods, so that it gets less confusing to use petgraph in circumstances where the term `weight` is fairly overloaded (as it's also a concept introduced by `osrank` and the `oscoin-graph-api`.