### PR TITLE
Refactor algorithm.rs and switch to the GraphAlgorithm trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -918,10 +918,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "oscoin-graph-api"
 version = "0.1.0"
-source = "git+https://github.com/oscoin/graph-api.git?rev=fa0aa9101224e1342d01faee7ba89fb4dc8a839d#fa0aa9101224e1342d01faee7ba89fb4dc8a839d"
-dependencies = [
- "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
+source = "git+https://github.com/oscoin/graph-api.git?rev=4940470811a6f6a3cac0d2c75349f02e8f7d7b0d#4940470811a6f6a3cac0d2c75349f02e8f7d7b0d"
 
 [[package]]
 name = "osrank-experiments"
@@ -938,7 +935,7 @@ dependencies = [
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ndarray 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "oscoin-graph-api 0.1.0 (git+https://github.com/oscoin/graph-api.git?rev=fa0aa9101224e1342d01faee7ba89fb4dc8a839d)",
+ "oscoin-graph-api 0.1.0 (git+https://github.com/oscoin/graph-api.git?rev=4940470811a6f6a3cac0d2c75349f02e8f7d7b0d)",
  "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2021,7 +2018,7 @@ dependencies = [
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 "checksum openssl-sys 0.9.47 (registry+https://github.com/rust-lang/crates.io-index)" = "75bdd6dbbb4958d38e47a1d2348847ad1eb4dc205dc5d37473ae504391865acc"
 "checksum ordermap 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a86ed3f5f244b372d6b1a00b72ef7f8876d0bc6a78a4c9985c53614041512063"
-"checksum oscoin-graph-api 0.1.0 (git+https://github.com/oscoin/graph-api.git?rev=fa0aa9101224e1342d01faee7ba89fb4dc8a839d)" = "<none>"
+"checksum oscoin-graph-api 0.1.0 (git+https://github.com/oscoin/graph-api.git?rev=4940470811a6f6a3cac0d2c75349f02e8f7d7b0d)" = "<none>"
 "checksum output_vt100 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
 "checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -918,7 +918,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "oscoin-graph-api"
 version = "0.1.0"
-source = "git+https://github.com/oscoin/graph-api.git?rev=4a115143882a7699a2537fbe99546f0948e21014#4a115143882a7699a2537fbe99546f0948e21014"
+source = "git+https://github.com/oscoin/graph-api.git?rev=fa0aa9101224e1342d01faee7ba89fb4dc8a839d#fa0aa9101224e1342d01faee7ba89fb4dc8a839d"
 dependencies = [
  "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -938,7 +938,7 @@ dependencies = [
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ndarray 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "oscoin-graph-api 0.1.0 (git+https://github.com/oscoin/graph-api.git?rev=4a115143882a7699a2537fbe99546f0948e21014)",
+ "oscoin-graph-api 0.1.0 (git+https://github.com/oscoin/graph-api.git?rev=fa0aa9101224e1342d01faee7ba89fb4dc8a839d)",
  "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2021,7 +2021,7 @@ dependencies = [
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 "checksum openssl-sys 0.9.47 (registry+https://github.com/rust-lang/crates.io-index)" = "75bdd6dbbb4958d38e47a1d2348847ad1eb4dc205dc5d37473ae504391865acc"
 "checksum ordermap 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a86ed3f5f244b372d6b1a00b72ef7f8876d0bc6a78a4c9985c53614041512063"
-"checksum oscoin-graph-api 0.1.0 (git+https://github.com/oscoin/graph-api.git?rev=4a115143882a7699a2537fbe99546f0948e21014)" = "<none>"
+"checksum oscoin-graph-api 0.1.0 (git+https://github.com/oscoin/graph-api.git?rev=fa0aa9101224e1342d01faee7ba89fb4dc8a839d)" = "<none>"
 "checksum output_vt100 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
 "checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ rand = "=0.7"
 rand_xorshift = "=0.2.0"
 
 #Doman-specific crates
-oscoin-graph-api = { git = "https://github.com/oscoin/graph-api.git", rev = "4a115143882a7699a2537fbe99546f0948e21014" }
+oscoin-graph-api = { git = "https://github.com/oscoin/graph-api.git", rev = "fa0aa9101224e1342d01faee7ba89fb4dc8a839d" }
 
 # Binary-only dependencies
 # See: https://stackoverflow.com/questions/35711044/how-can-i-specify-binary-only-dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ rand = "=0.7"
 rand_xorshift = "=0.2.0"
 
 #Doman-specific crates
-oscoin-graph-api = { git = "https://github.com/oscoin/graph-api.git", rev = "fa0aa9101224e1342d01faee7ba89fb4dc8a839d" }
+oscoin-graph-api = { git = "https://github.com/oscoin/graph-api.git", rev = "4940470811a6f6a3cac0d2c75349f02e8f7d7b0d" }
 
 # Binary-only dependencies
 # See: https://stackoverflow.com/questions/35711044/how-can-i-specify-binary-only-dependencies

--- a/benches/osrank_naive.rs
+++ b/benches/osrank_naive.rs
@@ -191,7 +191,7 @@ fn bench_rank_network(c: &mut Criterion) {
     c.bench(
         &info,
         Benchmark::new("sample size 10", move |b| {
-            b.iter(|| rank_network(&walks, &mut network, &ctx.ledger_view, &ctx.from_osrank))
+            b.iter(|| rank_network(&walks, &mut network, &ctx.ledger_view, &ctx.set_osrank))
         })
         .sample_size(10),
     );

--- a/benches/osrank_naive.rs
+++ b/benches/osrank_naive.rs
@@ -8,20 +8,32 @@ use crate::rand::SeedableRng;
 use criterion::*;
 use itertools::Itertools;
 use num_traits::Zero;
-use oscoin_graph_api::{GraphObject, GraphWriter};
-use osrank::algorithm::{osrank_naive, random_walk, rank_network};
+use oscoin_graph_api::{GraphAlgorithm, GraphWriter};
+use osrank::algorithm::{random_walk, rank_network, OsrankNaiveAlgorithm, OsrankNaiveMockContext};
 use osrank::importers::csv::import_network;
 use osrank::protocol_traits::graph::GraphExtras;
 use osrank::protocol_traits::ledger::{LedgerView, MockLedger};
-use osrank::types::network::{Artifact, ArtifactType, DependencyType, Network};
-use osrank::types::{Osrank, Weight};
+use osrank::types::mock::{Mock, MockNetwork};
+use osrank::types::network::{ArtifactType, DependencyType, Network};
+use osrank::types::Weight;
 use rand_xorshift::XorShiftRng;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 
-type MockNetwork = Network<f64>;
+fn construct_osrank_naive_algorithm<'a>() -> (
+    Mock<OsrankNaiveAlgorithm<'a, MockNetwork, MockLedger>>,
+    OsrankNaiveMockContext<'a, MockNetwork>,
+) {
+    let algo: Mock<OsrankNaiveAlgorithm<MockNetwork, MockLedger>> = Mock {
+        unmock: OsrankNaiveAlgorithm::default(),
+    };
 
-fn construct_network_small() -> Network<f64> {
+    let ctx = OsrankNaiveMockContext::default();
+
+    (algo, ctx)
+}
+
+fn construct_network_small() -> MockNetwork {
     let mut network = Network::default();
     for node in &["p1", "p2", "p3"] {
         network.add_node(
@@ -64,7 +76,7 @@ fn construct_network_small() -> Network<f64> {
     network
 }
 
-fn construct_network(meta_num: usize, contributions_num: usize) -> Network<f64> {
+fn construct_network(meta_num: usize, contributions_num: usize) -> MockNetwork {
     let deps_reader = BufReader::new(File::open("data/cargo_dependencies.csv").unwrap())
         .split(b'\n')
         .map(|l| l.unwrap())
@@ -99,31 +111,21 @@ fn construct_network(meta_num: usize, contributions_num: usize) -> Network<f64> 
     .unwrap()
 }
 
-fn run_osrank_naive(mut network: &mut Network<f64>, iter: u32, initial_seed: [u8; 16]) {
-    let mut mock_ledger = MockLedger::default();
-    mock_ledger.set_random_walks_num(iter);
-    let set_osrank = Box::new(|node: &Artifact<String>, rank| match node.data() {
-        ArtifactType::Project { osrank: _ } => ArtifactType::Project { osrank: rank },
-        ArtifactType::Account { osrank: _ } => ArtifactType::Account { osrank: rank },
-    });
-    osrank_naive::<MockLedger, MockNetwork, XorShiftRng>(
-        None,
-        &mut network,
-        &mock_ledger,
-        initial_seed,
-        set_osrank,
-    )
-    .unwrap();
+fn run_osrank_naive(mut network: &mut MockNetwork, iter: u32, initial_seed: [u8; 16]) {
+    let (algo, mut ctx) = construct_osrank_naive_algorithm();
+    ctx.ledger_view.set_random_walks_num(iter);
+    algo.execute(&mut ctx, &mut network, initial_seed).unwrap();
 }
 
-fn run_random_walk(network: &Network<f64>, iter: u32, initial_seed: [u8; 16]) {
+fn run_random_walk(network: &MockNetwork, iter: u32, initial_seed: [u8; 16]) {
     let mut mock_ledger = MockLedger::default();
+
     mock_ledger.set_random_walks_num(iter);
     random_walk::<MockLedger, MockNetwork, XorShiftRng>(
         None,
         &network,
         &mock_ledger,
-        XorShiftRng::from_seed(initial_seed.clone()),
+        &mut XorShiftRng::from_seed(initial_seed.clone()),
     )
     .unwrap();
 }
@@ -143,7 +145,10 @@ fn bench_osrank_naive_on_small_network(c: &mut Criterion) {
 // run with a lower sample size to speed things up
 fn bench_osrank_naive_on_sample_csv(c: &mut Criterion) {
     let mut network = construct_network(1_000, 10_000);
-    let info = format!("(dev) osrank with {:?} nodes, iter: 1", &network.node_count());
+    let info = format!(
+        "(dev) osrank with {:?} nodes, iter: 1",
+        &network.node_count()
+    );
     c.bench(
         &info,
         Benchmark::new("sample size 10", move |b| {
@@ -166,18 +171,15 @@ fn bench_random_walk_on_csv(c: &mut Criterion) {
 
 fn bench_rank_network(c: &mut Criterion) {
     let mut network = construct_network(1_000, 10_000);
-    let mut mock_ledger = MockLedger::default();
-    mock_ledger.set_random_walks_num(1);
-    let set_osrank: Box<dyn Fn(&Artifact<String>, Osrank) -> ArtifactType> =
-        Box::new(|node: &Artifact<String>, rank| match node.data() {
-            ArtifactType::Project { osrank: _ } => ArtifactType::Project { osrank: rank },
-            ArtifactType::Account { osrank: _ } => ArtifactType::Account { osrank: rank },
-        });
+
+    let (_algo, mut ctx) = construct_osrank_naive_algorithm();
+    ctx.ledger_view.set_random_walks_num(1);
+
     let walks = random_walk::<MockLedger, MockNetwork, XorShiftRng>(
         None,
         &network,
-        &mock_ledger,
-        XorShiftRng::from_seed([0; 16]),
+        &ctx.ledger_view,
+        &mut XorShiftRng::from_seed([0; 16]),
     )
     .unwrap()
     .walks;
@@ -189,7 +191,7 @@ fn bench_rank_network(c: &mut Criterion) {
     c.bench(
         &info,
         Benchmark::new("sample size 10", move |b| {
-            b.iter(|| rank_network(&walks, &mut network, &mock_ledger, &set_osrank))
+            b.iter(|| rank_network(&walks, &mut network, &ctx.ledger_view, &ctx.from_osrank))
         })
         .sample_size(10),
     );
@@ -207,9 +209,7 @@ fn bench_nightly_osrank_naive(c: &mut Criterion) {
             let nodes = &network.node_count();
             group.bench_function(
                 BenchmarkId::new(format!("Iter {}", &iter), nodes),
-                move |b| {
-                    b.iter(|| run_osrank_naive(&mut network, *iter as u32, [0; 16]))
-                }
+                move |b| b.iter(|| run_osrank_naive(&mut network, *iter as u32, [0; 16])),
             );
         }
 
@@ -218,9 +218,7 @@ fn bench_nightly_osrank_naive(c: &mut Criterion) {
             let nodes = &network.node_count();
             group.bench_function(
                 BenchmarkId::new(format!("Iter {}", &iter), nodes),
-                move |b| {
-                    b.iter(|| run_osrank_naive(&mut network, *iter as u32, [0; 16]))
-                }
+                move |b| b.iter(|| run_osrank_naive(&mut network, *iter as u32, [0; 16])),
             );
         }
     }
@@ -228,7 +226,8 @@ fn bench_nightly_osrank_naive(c: &mut Criterion) {
 }
 
 fn bench_nightly_random_walk(c: &mut Criterion) {
-    let mut group = c.benchmark_group("(nightly) Random walks with increasing iterator and node count");
+    let mut group =
+        c.benchmark_group("(nightly) Random walks with increasing iterator and node count");
     group.sample_size(10);
 
     for iter in &[1, 10, 100, 1_000] {
@@ -237,9 +236,7 @@ fn bench_nightly_random_walk(c: &mut Criterion) {
             let nodes = &network.node_count();
             group.bench_function(
                 BenchmarkId::new(format!("Iter {}", &iter), nodes),
-                move |b| {
-                    b.iter(|| run_random_walk(&network, *iter, [0; 16]))
-                }
+                move |b| b.iter(|| run_random_walk(&network, *iter, [0; 16])),
             );
         }
     }

--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -236,9 +236,9 @@ pub struct OsrankNaiveMockContext<'a, G = MockNetwork>
 where
     G: Graph,
 {
-    seed_set: Option<&'a SeedSet<Id<G::Node>>>,
-    ledger_view: MockLedger,
-    from_osrank: &'a (dyn Fn(&mut G::Node, Osrank) -> ()),
+    pub seed_set: Option<&'a SeedSet<Id<G::Node>>>,
+    pub ledger_view: MockLedger,
+    pub from_osrank: &'a (dyn Fn(&mut G::Node, Osrank) -> ()),
 }
 
 impl<'a> Default for OsrankNaiveMockContext<'a, MockNetwork> {
@@ -272,7 +272,7 @@ where
     type Output = ();
     type Context = OsrankNaiveMockContext<'a, G>;
     type Error = OsrankError;
-    type Rng = XorShiftRng;
+    type RngSeed = [u8; 16];
 
     fn execute(
         &self,

--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -16,7 +16,7 @@ use crate::types::Osrank;
 use core::iter::Iterator;
 use fraction::Fraction;
 use num_traits::{One, Zero};
-use oscoin_graph_api::{Edge, Graph, GraphAlgorithm, GraphObject, Id};
+use oscoin_graph_api::{Direction, Edge, Graph, GraphAlgorithm, GraphObject, Id};
 use rand::distributions::uniform::SampleUniform;
 use rand::distributions::WeightedError;
 use rand::seq::SliceRandom;
@@ -63,7 +63,7 @@ where
             // TODO distinguish account/project
             // TODO Should there be a safeguard so this doesn't run forever?
             while rng.gen::<f64>() < ledger_view.get_damping_factors().project {
-                let neighbors = network.neighbors(&current_node);
+                let neighbors = network.edges_directed(&current_node, Direction::Outgoing);
                 match neighbors.choose_weighted(rng, |item| {
                     network
                         .get_edge(&item.id)

--- a/src/types/mock.rs
+++ b/src/types/mock.rs
@@ -11,6 +11,12 @@ use rand::Rng;
 
 pub type MockNetwork = Network<f64>;
 
+/// Equivalent to `newtype Mock a = Mock a` in Haskell. Useful to define
+/// some trait which operates over mocks implementation only.
+pub struct Mock<A> {
+    pub unmock: A,
+}
+
 #[derive(Debug)]
 struct ArbitraryEdge<'a> {
     source: &'a String,


### PR DESCRIPTION
This patch switches the `algorithm.rs` module to use the `GraphAlgorithm` trait from `oscoin-graph-api`.