### PR TITLE
Add test for deterministic osrank

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,11 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "arrayref"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "arrayvec"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -924,6 +929,7 @@ source = "git+https://github.com/oscoin/graph-api.git?rev=4940470811a6f6a3cac0d2
 name = "osrank-experiments"
 version = "0.1.0"
 dependencies = [
+ "arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "csv 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1920,6 +1926,7 @@ dependencies = [
 "checksum alga 0.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "88c4144cd393075e782c633b4f9c5dea4811aed18ed59f518ae2ca2b553e3d09"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum approx 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08abcc3b4e9339e33a3d0a5ed15d84a687350c05689d825e0f6655eef9e76a94"
+"checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
 "checksum arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "92c7fb76bc8826a8b33b4ee5bb07a247a81e76764ab4d55e8f73e3a4d8808c71"
 "checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "0e49efa51329a5fd37e7c79db4621af617cd4e3e5bc224939808d076077077bf"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ failure_derive = { version = "0.1.5", optional = true}
 pretty_assertions = "0.6.1"
 tempfile = "^3.1.0"
 criterion = "0.3.0"
+arrayref = "0.3.5"
 
 [[bench]]
 name = "osrank_naive"

--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -326,6 +326,7 @@ where
 #[cfg(test)]
 mod tests {
 
+    extern crate arrayref;
     extern crate oscoin_graph_api;
     extern crate quickcheck;
     extern crate rand;
@@ -374,6 +375,46 @@ mod tests {
     #[test]
     fn osrank_is_approx_probability_distribution() {
         quickcheck(prop_osrank_is_approx_probability_distribution as fn(MockNetwork) -> TestResult);
+    }
+
+    // Test that given the same initial seed, two osrank algorithms yields
+    // exactly the same result.
+    fn prop_osrank_is_deterministic(mut graph: MockNetwork, entropy: Vec<u8>) -> TestResult {
+        if graph.is_empty() || entropy.len() < 16 {
+            return TestResult::discard();
+        }
+
+        let initial_seed: &[u8; 16] = array_ref!(entropy.as_slice(), 0, 16);
+
+        let algo: Mock<OsrankNaiveAlgorithm<MockNetwork, MockLedger>> = Mock {
+            unmock: OsrankNaiveAlgorithm::default(),
+        };
+
+        let mut ctx1 = OsrankNaiveMockContext::default();
+        let mut ctx2 = OsrankNaiveMockContext::default();
+        let mut second_graph = graph.clone();
+
+        let first_run = algo.execute(&mut ctx1, &mut graph, *initial_seed);
+        let second_run = algo.execute(&mut ctx2, &mut second_graph, *initial_seed);
+
+        assert_eq!(first_run, second_run);
+
+        let first_ranks = graph
+            .nodes()
+            .map(|node| node.data().get_osrank())
+            .collect::<Vec<Osrank>>();
+
+        let second_ranks = second_graph
+            .nodes()
+            .map(|node| node.data().get_osrank())
+            .collect::<Vec<Osrank>>();
+
+        TestResult::from_bool(first_ranks == second_ranks)
+    }
+
+    #[test]
+    fn osrank_is_deterministic() {
+        quickcheck(prop_osrank_is_deterministic as fn(MockNetwork, Vec<u8>) -> TestResult);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,9 @@ extern crate quickcheck;
 #[cfg(test)]
 #[macro_use(quickcheck)]
 extern crate quickcheck_macros;
+#[cfg(test)]
+#[macro_use]
+extern crate arrayref;
 
 pub mod adjacency;
 pub mod algorithm;


### PR DESCRIPTION
Fixes #61.

This PR adds arguably the most important test of the testsuite: it tests (via quickcheck) that given a random graph and a random initial seed, if we run the osrank algorithm on the same (cloned) graph and the same seed twice, the results matches, i.e. given a fixed seed, the algorithm is deterministic.