### PR TITLE
Port the code to use the GraphAnnotator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -923,7 +923,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "oscoin-graph-api"
 version = "0.1.0"
-source = "git+https://github.com/oscoin/graph-api.git?rev=e2ee956a94a4ba7db4ca213f2fa27c2c89d9e2ad#e2ee956a94a4ba7db4ca213f2fa27c2c89d9e2ad"
+source = "git+https://github.com/oscoin/graph-api.git?rev=c8eed614f0d8d4f0ab265416f8caf2f4c60a1560#c8eed614f0d8d4f0ab265416f8caf2f4c60a1560"
 
 [[package]]
 name = "osrank-experiments"
@@ -941,7 +941,7 @@ dependencies = [
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ndarray 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "oscoin-graph-api 0.1.0 (git+https://github.com/oscoin/graph-api.git?rev=e2ee956a94a4ba7db4ca213f2fa27c2c89d9e2ad)",
+ "oscoin-graph-api 0.1.0 (git+https://github.com/oscoin/graph-api.git?rev=c8eed614f0d8d4f0ab265416f8caf2f4c60a1560)",
  "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2025,7 +2025,7 @@ dependencies = [
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 "checksum openssl-sys 0.9.47 (registry+https://github.com/rust-lang/crates.io-index)" = "75bdd6dbbb4958d38e47a1d2348847ad1eb4dc205dc5d37473ae504391865acc"
 "checksum ordermap 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a86ed3f5f244b372d6b1a00b72ef7f8876d0bc6a78a4c9985c53614041512063"
-"checksum oscoin-graph-api 0.1.0 (git+https://github.com/oscoin/graph-api.git?rev=e2ee956a94a4ba7db4ca213f2fa27c2c89d9e2ad)" = "<none>"
+"checksum oscoin-graph-api 0.1.0 (git+https://github.com/oscoin/graph-api.git?rev=c8eed614f0d8d4f0ab265416f8caf2f4c60a1560)" = "<none>"
 "checksum output_vt100 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
 "checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -923,7 +923,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "oscoin-graph-api"
 version = "0.1.0"
-source = "git+https://github.com/oscoin/graph-api.git?rev=4940470811a6f6a3cac0d2c75349f02e8f7d7b0d#4940470811a6f6a3cac0d2c75349f02e8f7d7b0d"
+source = "git+https://github.com/oscoin/graph-api.git?rev=e2ee956a94a4ba7db4ca213f2fa27c2c89d9e2ad#e2ee956a94a4ba7db4ca213f2fa27c2c89d9e2ad"
 
 [[package]]
 name = "osrank-experiments"
@@ -941,7 +941,7 @@ dependencies = [
  "itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ndarray 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "oscoin-graph-api 0.1.0 (git+https://github.com/oscoin/graph-api.git?rev=4940470811a6f6a3cac0d2c75349f02e8f7d7b0d)",
+ "oscoin-graph-api 0.1.0 (git+https://github.com/oscoin/graph-api.git?rev=e2ee956a94a4ba7db4ca213f2fa27c2c89d9e2ad)",
  "petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_assertions 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2025,7 +2025,7 @@ dependencies = [
 "checksum openssl-probe 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 "checksum openssl-sys 0.9.47 (registry+https://github.com/rust-lang/crates.io-index)" = "75bdd6dbbb4958d38e47a1d2348847ad1eb4dc205dc5d37473ae504391865acc"
 "checksum ordermap 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "a86ed3f5f244b372d6b1a00b72ef7f8876d0bc6a78a4c9985c53614041512063"
-"checksum oscoin-graph-api 0.1.0 (git+https://github.com/oscoin/graph-api.git?rev=4940470811a6f6a3cac0d2c75349f02e8f7d7b0d)" = "<none>"
+"checksum oscoin-graph-api 0.1.0 (git+https://github.com/oscoin/graph-api.git?rev=e2ee956a94a4ba7db4ca213f2fa27c2c89d9e2ad)" = "<none>"
 "checksum output_vt100 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "53cdc5b785b7a58c5aad8216b3dfa114df64b0b06ae6e1501cef91df2fbdf8f9"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
 "checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ rand = "=0.7"
 rand_xorshift = "=0.2.0"
 
 #Doman-specific crates
-oscoin-graph-api = { git = "https://github.com/oscoin/graph-api.git", rev = "4940470811a6f6a3cac0d2c75349f02e8f7d7b0d" }
+oscoin-graph-api = { git = "https://github.com/oscoin/graph-api.git", rev = "e2ee956a94a4ba7db4ca213f2fa27c2c89d9e2ad" }
 
 # Binary-only dependencies
 # See: https://stackoverflow.com/questions/35711044/how-can-i-specify-binary-only-dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ rand = "=0.7"
 rand_xorshift = "=0.2.0"
 
 #Doman-specific crates
-oscoin-graph-api = { git = "https://github.com/oscoin/graph-api.git", rev = "e2ee956a94a4ba7db4ca213f2fa27c2c89d9e2ad" }
+oscoin-graph-api = { git = "https://github.com/oscoin/graph-api.git", rev = "c8eed614f0d8d4f0ab265416f8caf2f4c60a1560" }
 
 # Binary-only dependencies
 # See: https://stackoverflow.com/questions/35711044/how-can-i-specify-binary-only-dependencies

--- a/benches/osrank_naive_development.rs
+++ b/benches/osrank_naive_development.rs
@@ -57,7 +57,7 @@ fn bench_random_walk_on_csv(c: &mut Criterion) {
 fn bench_rank_network(c: &mut Criterion) {
     let mut network = construct_network(1_000, 10_000);
 
-    let (_algo, mut ctx) = construct_osrank_naive_algorithm();
+    let (_algo, mut annotator, mut ctx) = construct_osrank_naive_algorithm();
     ctx.ledger_view.set_random_walks_num(1);
 
     let walks = random_walk::<MockLedger, MockNetwork, XorShiftRng>(
@@ -77,7 +77,15 @@ fn bench_rank_network(c: &mut Criterion) {
     c.bench(
         &info,
         Benchmark::new("sample size 10", move |b| {
-            b.iter(|| rank_network(&walks, &mut network, &ctx.ledger_view, &ctx.set_osrank))
+            b.iter(|| {
+                rank_network(
+                    &walks,
+                    &mut network,
+                    &ctx.ledger_view,
+                    &mut annotator,
+                    &ctx.to_annotation,
+                )
+            })
         })
         .sample_size(10),
     );

--- a/src/protocol_traits/graph.rs
+++ b/src/protocol_traits/graph.rs
@@ -7,7 +7,7 @@ extern crate rand;
 
 /// This is a compatibility-shim trait for things that the "official"
 /// GraphAPI trait(s) don't give us for free.
-pub trait GraphExtras: oscoin::Graph + oscoin::GraphDataWriter + oscoin::GraphWriter {
+pub trait GraphExtras: oscoin::Graph {
     fn lookup_node_metadata(
         &self,
         node_id: &oscoin::Id<Self::Node>,


### PR DESCRIPTION
This PR ports the code to use the new `GraphAnnotator` abstraction.

It's marked as draft as it relies on the unreleased new version of `graph-api`.