### PR TITLE
Have a go at parallelising the osrank naive algorithm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,7 +233,7 @@ dependencies = [
  "rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_os 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xoshiro 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rayon 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -252,33 +252,24 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "crossbeam-epoch 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "crossbeam-deque"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "crossbeam-epoch 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-epoch 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "arrayvec 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memoffset 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -286,12 +277,12 @@ name = "crossbeam-queue"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -685,8 +676,11 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.2.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "mime"
@@ -961,6 +955,8 @@ dependencies = [
  "quickcheck_macros 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xorshift 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_xoshiro 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.94 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1154,7 +1150,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "getrandom 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_chacha 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_hc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1170,10 +1166,9 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "autocfg 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "c2-chacha 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1289,28 +1284,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xoshiro"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rawpointer"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rayon"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "crossbeam-deque 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-deque 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "rayon-core 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rayon-core 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rayon-core"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "crossbeam-deque 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-deque 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1447,6 +1450,11 @@ dependencies = [
 [[package]]
 name = "scopeguard"
 version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "scopeguard"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1701,7 +1709,7 @@ name = "tokio-executor"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1720,7 +1728,7 @@ name = "tokio-reactor"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1762,7 +1770,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-deque 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1776,7 +1784,7 @@ name = "tokio-timer"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-executor 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1985,11 +1993,10 @@ dependencies = [
 "checksum crc32fast 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ba125de2af0df55319f41944744ad91c71113bf74a4646efff39afe1f6842db1"
 "checksum criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "938703e165481c8d612ea3479ac8342e5615185db37765162e762ec3523e2fc6"
 "checksum criterion-plot 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eccdc6ce8bbe352ca89025bee672aa6d24f4eb8c53e3a8b5d1bc58011da072a2"
-"checksum crossbeam-deque 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "05e44b8cf3e1a625844d1750e1f7820da46044ff6d28f4d43e455ba3e5bb2c13"
 "checksum crossbeam-deque 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b18cd2e169ad86297e6bc0ad9aa679aee9daa4f19e8163860faf7c164e4f5a71"
-"checksum crossbeam-epoch 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "04c9e3102cc2d69cd681412141b390abd55a362afc1540965dad0ad4d34280b4"
+"checksum crossbeam-epoch 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fedcd6772e37f3da2a9af9bf12ebe046c0dfe657992377b4df982a2b54cd37a9"
 "checksum crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b"
-"checksum crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f8306fcef4a7b563b76b7dd949ca48f52bc1141aa067d2ea09565f3e2652aa5c"
+"checksum crossbeam-utils 0.6.6 (registry+https://github.com/rust-lang/crates.io-index)" = "04973fa96e96579258a5091af6003abde64af786b860f18622b82e026cca60e6"
 "checksum csv 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "37519ccdfd73a75821cac9319d4fce15a81b9fcf75f951df5b9988aa3a0af87d"
 "checksum csv-core 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "9b5cadb6b25c77aeff80ba701712494213f4a8418fcda2ee11b6560c3ad0bf4c"
 "checksum ctor 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "3b4c17619643c1252b5f690084b82639dd7fac141c57c8e77a00e0148132092c"
@@ -2035,7 +2042,7 @@ dependencies = [
 "checksum matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 "checksum matrixmultiply 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "dcad67dcec2d58ff56f6292582377e6921afdf3bfbd533e26fb8900ae575e002"
 "checksum memchr 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2efc7bc57c883d4a4d6e3246905283d8dae951bb3bd32f49d6ef297f546e1c39"
-"checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
+"checksum memoffset 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ce6075db033bbbb7ee5a0bbd3a3186bbae616f57fb001c485c7ff77955f8177f"
 "checksum mime 0.3.13 (registry+https://github.com/rust-lang/crates.io-index)" = "3e27ca21f40a310bd06d9031785f4801710d566c184a6e15bad4f1d9b65f9425"
 "checksum mime_guess 2.0.0-alpha.6 (registry+https://github.com/rust-lang/crates.io-index)" = "30de2e4613efcba1ec63d8133f344076952090c122992a903359be5a4f99c3ed"
 "checksum miniz_oxide 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b6c3756d66cf286314d5f7ebe74886188a9a92f5eee68b06f31ac2b4f314c99d"
@@ -2084,7 +2091,7 @@ dependencies = [
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 "checksum rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d47eab0e83d9693d40f825f86948aa16eff6750ead4bdffc4ab95b8b3a7f052c"
 "checksum rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
-"checksum rand_chacha 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e193067942ef6f485a349a113329140d0ab9e2168ce92274499bb0e9a4190d9d"
+"checksum rand_chacha 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "03a2a90da8c7523f554344f921aa97283eadf6ac484a6d2a7d0212fa7f8d6853"
 "checksum rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
 "checksum rand_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d0e7a549d590831370895ab7ba4ea0c1b6b011d106b5ff2da6eee112615e6dc0"
 "checksum rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "615e683324e75af5d43d8f7a39ffe3ee4a9dc42c5c701167a71dc59c3a493aca"
@@ -2098,9 +2105,10 @@ dependencies = [
 "checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 "checksum rand_xorshift 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "77d416b86801d23dde1aa643023b775c3a462efc0ed96443add11546cdf1dca8"
 "checksum rand_xoshiro 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0e18c91676f670f6f0312764c759405f13afb98d5d73819840cf72a518487bff"
+"checksum rand_xoshiro 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9fcdd2e881d02f1d9390ae47ad8e5696a9e4be7b547a1da2afbc61973217004"
 "checksum rawpointer 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ebac11a9d2e11f2af219b8b8d833b76b1ea0e054aa0e8d8e9e4cbde353bdf019"
-"checksum rayon 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a4b0186e22767d5b9738a05eab7c6ac90b15db17e5b5f9bd87976dd7d89a10a4"
-"checksum rayon-core 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ebbe0df8435ac0c397d467b6cad6d25543d06e8a019ef3f6af3c384597515bd2"
+"checksum rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "83a27732a533a1be0a0035a111fe76db89ad312f6f0347004c220c57f209a123"
+"checksum rayon-core 1.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "98dcf634205083b17d0861252431eb2acbfb698ab7478a2d20de07954f47ec7b"
 "checksum rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
 "checksum redox_syscall 0.1.55 (registry+https://github.com/rust-lang/crates.io-index)" = "cbd093aba707641a1ebf784490f00ceb889b21953774de1d5fba05d1ee1d283c"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
@@ -2116,6 +2124,7 @@ dependencies = [
 "checksum same-file 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "585e8ddcedc187886a30fa705c47985c3fa88d06624095856b36ca0b82ff4421"
 "checksum schannel 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "f2f6abf258d99c3c1c5c2131d99d064e94b7b3dd5f416483057f308fea253339"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
+"checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
 "checksum security-framework 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eee63d0f4a9ec776eeb30e220f0bc1e092c3ad744b2a379e3993070364d3adc2"
 "checksum security-framework-sys 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9636f8989cbf61385ae4824b98c1aaa54c994d7d8b41f11c601ed799f0549a56"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -954,7 +954,6 @@ dependencies = [
  "quickcheck 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quickcheck_macros 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand_xorshift 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_xoshiro 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.18 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1265,14 +1264,6 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "rand_core 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2103,7 +2094,6 @@ dependencies = [
 "checksum rand_os 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a788ae3edb696cfcba1c19bfd388cc4b8c21f8a408432b199c072825084da58a"
 "checksum rand_pcg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
 "checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
-"checksum rand_xorshift 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "77d416b86801d23dde1aa643023b775c3a462efc0ed96443add11546cdf1dca8"
 "checksum rand_xoshiro 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0e18c91676f670f6f0312764c759405f13afb98d5d73819840cf72a518487bff"
 "checksum rand_xoshiro 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9fcdd2e881d02f1d9390ae47ad8e5696a9e4be7b547a1da2afbc61973217004"
 "checksum rawpointer 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ebac11a9d2e11f2af219b8b8d833b76b1ea0e054aa0e8d8e9e4cbde353bdf019"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ derive_more = "^0.13"
 itertools = "^0.8.0"
 fnv = "^1.0.3"
 log = "0.4.0"
+rayon = "^1.2.0"
 
 # We need to lock quickcheck to the same version of rand used by this crate.
 quickcheck = "=0.9"
@@ -69,6 +70,7 @@ sprs = "^0.6"
 ndarray = "=0.12.1"
 rand = "=0.7"
 rand_xorshift = "=0.2.0"
+rand_xoshiro  = "=0.4.0"
 
 #Doman-specific crates
 oscoin-graph-api = { git = "https://github.com/oscoin/graph-api.git", rev = "c8eed614f0d8d4f0ab265416f8caf2f4c60a1560" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ required-features = ["build-binary"]
 
 [features]
 
-build-binary = ["reqwest", "clap", "failure", "failure_derive", "env_logger"]
+build-binary = ["reqwest", "clap", "failure", "failure_derive"]
 
 [dependencies]
 
@@ -52,6 +52,7 @@ derive_more = "^0.13"
 itertools = "^0.8.0"
 fnv = "^1.0.3"
 log = "0.4.0"
+env_logger = "^0.6.2"
 rayon = "^1.2.0"
 
 # We need to lock quickcheck to the same version of rand used by this crate.
@@ -69,7 +70,6 @@ fraction = "0.6"
 sprs = "^0.6"
 ndarray = "=0.12.1"
 rand = "=0.7"
-rand_xorshift = "=0.2.0"
 rand_xoshiro  = "=0.4.0"
 
 #Doman-specific crates
@@ -81,7 +81,6 @@ reqwest = { version = "^0.9", optional = true }
 clap = { version = "^2.33", optional = true }
 failure = { version = "0.1.5", optional = true}
 failure_derive = { version = "0.1.5", optional = true}
-env_logger = { version = "0.6.2", optional = true}
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"

--- a/benches/osrank_naive_development.rs
+++ b/benches/osrank_naive_development.rs
@@ -6,7 +6,6 @@ extern crate rand_xorshift;
 
 use criterion::*;
 
-use crate::rand::SeedableRng;
 use osrank::algorithm::{random_walk, rank_network};
 use osrank::benchmarks::util::{
     construct_network, construct_network_small, construct_osrank_naive_algorithm, dev,
@@ -15,7 +14,8 @@ use osrank::benchmarks::util::{
 use osrank::protocol_traits::graph::GraphExtras;
 use osrank::protocol_traits::ledger::{LedgerView, MockLedger};
 use osrank::types::mock::MockNetwork;
-use rand_xorshift::XorShiftRng;
+use rand::SeedableRng;
+use rand_xoshiro::Xoshiro256StarStar;
 
 // Benchmarks intended to be run for development are appended with `(dev) `.
 // `cargo bench -- dev` will only run them.
@@ -23,7 +23,7 @@ fn bench_osrank_naive_on_small_network(c: &mut Criterion) {
     let mut network = construct_network_small();
     c.bench_function(&dev("osrank by random seed"), move |b| {
         b.iter(|| {
-            let rand_vec: [u8; 16] = rand::random();
+            let rand_vec: [u8; 32] = rand::random();
             run_osrank_naive(&mut network, 1, rand_vec)
         })
     });
@@ -36,7 +36,7 @@ fn bench_osrank_naive_on_sample_csv(c: &mut Criterion) {
     c.bench(
         &info,
         Benchmark::new("sample size 10", move |b| {
-            b.iter(|| run_osrank_naive(&mut network, 1, [0; 16]))
+            b.iter(|| run_osrank_naive(&mut network, 1, [0; 32]))
         })
         .sample_size(10),
     );
@@ -50,7 +50,7 @@ fn bench_random_walk_on_csv(c: &mut Criterion) {
     )
     .as_str());
     c.bench_function(&info, move |b| {
-        b.iter(|| run_random_walk(&network, 1, [0; 16]))
+        b.iter(|| run_random_walk(&network, 1, [0; 32]))
     });
 }
 
@@ -60,11 +60,11 @@ fn bench_rank_network(c: &mut Criterion) {
     let (_algo, mut annotator, mut ctx) = construct_osrank_naive_algorithm();
     ctx.ledger_view.set_random_walks_num(1);
 
-    let walks = random_walk::<MockLedger, MockNetwork, XorShiftRng>(
+    let walks = random_walk::<MockLedger, MockNetwork, Xoshiro256StarStar>(
         None,
         &network,
         &ctx.ledger_view,
-        &mut XorShiftRng::from_seed([0; 16]),
+        &Xoshiro256StarStar::from_seed([0; 32]),
     )
     .unwrap()
     .walks;

--- a/benches/osrank_naive_development.rs
+++ b/benches/osrank_naive_development.rs
@@ -2,7 +2,7 @@
 extern crate criterion;
 extern crate oscoin_graph_api;
 extern crate rand;
-extern crate rand_xorshift;
+extern crate rand_xoshiro;
 
 use criterion::*;
 

--- a/benches/osrank_naive_nightly.rs
+++ b/benches/osrank_naive_nightly.rs
@@ -22,7 +22,7 @@ fn bench_nightly_osrank_naive(c: &mut Criterion) {
             let nodes = &network.node_count();
             group.bench_function(
                 BenchmarkId::new(format!("Iter {}", &iter), nodes),
-                move |b| b.iter(|| run_osrank_naive(&mut network, *iter as u32, [0; 16])),
+                move |b| b.iter(|| run_osrank_naive(&mut network, *iter as u32, [0; 32])),
             );
         }
 
@@ -31,7 +31,7 @@ fn bench_nightly_osrank_naive(c: &mut Criterion) {
         //     let nodes = &network.node_count();
         //     group.bench_function(
         //         BenchmarkId::new(format!("Iter {}", &iter), nodes),
-        //         move |b| b.iter(|| run_osrank_naive(&mut network, *iter as u32, [0; 16])),
+        //         move |b| b.iter(|| run_osrank_naive(&mut network, *iter as u32, [0; 32])),
         //     );
         // }
     }
@@ -50,7 +50,7 @@ fn bench_nightly_random_walk(c: &mut Criterion) {
             let nodes = &network.node_count();
             group.bench_function(
                 BenchmarkId::new(format!("Iter {}", &iter), nodes),
-                move |b| b.iter(|| run_random_walk(&network, *iter, [0; 16])),
+                move |b| b.iter(|| run_random_walk(&network, *iter, [0; 32])),
             );
         }
     }
@@ -59,7 +59,6 @@ fn bench_nightly_random_walk(c: &mut Criterion) {
 
 criterion_group!(
     benches,
-    bench_nightly_osrank_naive
-    // bench_nightly_random_walk
+    bench_nightly_osrank_naive // bench_nightly_random_walk
 );
 criterion_main!(benches);

--- a/benches/osrank_naive_nightly.rs
+++ b/benches/osrank_naive_nightly.rs
@@ -2,7 +2,7 @@
 extern crate criterion;
 extern crate oscoin_graph_api;
 extern crate rand;
-extern crate rand_xorshift;
+extern crate rand_xoshiro;
 
 use criterion::*;
 

--- a/bin/export_gephi.rs
+++ b/bin/export_gephi.rs
@@ -121,7 +121,7 @@ fn main() -> Result<(), AppError> {
 
     debug!("Calculating the osrank (mock naive algorithm)...");
 
-    let initial_seed = [0; 16];
+    let initial_seed = [0; 32];
     let mut annotator: MockAnnotator<MockNetwork> = Default::default();
 
     algo.execute(&mut ctx, &mut network, &mut annotator, initial_seed)?;

--- a/bin/export_gephi.rs
+++ b/bin/export_gephi.rs
@@ -130,7 +130,11 @@ fn main() -> Result<(), AppError> {
     gexf::export_graph(&network, &Path::new(&(out.to_owned() + ".gexf")))?;
 
     debug!("Exporting the network to .graphml ...");
-    graphml::export_graph(&network, &Path::new(&(out.to_owned() + ".graphml")))?;
+    graphml::export_graph(
+        &network,
+        annotator,
+        &Path::new(&(out.to_owned() + ".graphml")),
+    )?;
 
     debug!("Done.");
 

--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -416,7 +416,7 @@ mod tests {
     extern crate oscoin_graph_api;
     extern crate quickcheck;
     extern crate rand;
-    extern crate rand_xorshift;
+    extern crate rand_xoshiro;
 
     use super::*;
     use crate::protocol_traits::ledger::MockLedger;

--- a/src/algorithm.rs
+++ b/src/algorithm.rs
@@ -48,7 +48,7 @@ impl From<rand::Error> for OsrankError {
 /// The output from a random walk.
 pub struct WalkResult<G, I>
 where
-    I: Eq + Hash,
+    I: Eq + Hash + Sync + Send,
 {
     network_view: G,
     pub walks: RandomWalks<I>,
@@ -208,8 +208,10 @@ where
         Some(_) => {
             // Phase1, rank the network and produce a NetworkView.
             let phase1 = random_walk(seed_set, &*network, ledger_view, rng)?;
+
             // Phase2, compute the osrank only on the NetworkView
             let phase2 = random_walk(None, &phase1.network_view, ledger_view, rng)?;
+
             rank_network(
                 &phase2.walks,
                 &*network,
@@ -241,7 +243,7 @@ fn rank_node<L, G>(
 where
     L: LedgerView,
     G: GraphExtras,
-    <G::Node as GraphObject>::Id: Eq + Clone + Hash,
+    <G::Node as GraphObject>::Id: Eq + Clone + Hash + Sync + Send,
 {
     let total_walks = random_walks.len();
     let node_visits = random_walks.count_visits(&node_id);
@@ -279,7 +281,7 @@ where
     L: LedgerView,
     G: GraphExtras,
     A: GraphAnnotator,
-    <G::Node as GraphObject>::Id: Eq + Clone + Hash,
+    <G::Node as GraphObject>::Id: Eq + Clone + Hash + Sync + Send,
 {
     for node in network_view.nodes() {
         let rank = rank_node::<L, G>(&random_walks, node.id().clone(), ledger_view);

--- a/src/benchmarks/util.rs
+++ b/src/benchmarks/util.rs
@@ -4,7 +4,7 @@
 extern crate itertools;
 extern crate oscoin_graph_api;
 extern crate rand;
-extern crate rand_xorshift;
+extern crate rand_xoshiro;
 
 use crate::algorithm::{random_walk, OsrankNaiveAlgorithm, OsrankNaiveMockContext};
 use crate::importers::csv::import_network;
@@ -139,7 +139,7 @@ pub fn run_random_walk(network: &MockNetwork, iter: u32, initial_seed: [u8; 32])
         None,
         &network,
         &mock_ledger,
-        &mut Xoshiro256StarStar::from_seed(initial_seed),
+        &Xoshiro256StarStar::from_seed(initial_seed),
     )
     .unwrap();
 }

--- a/src/benchmarks/util.rs
+++ b/src/benchmarks/util.rs
@@ -16,7 +16,7 @@ use itertools::Itertools;
 use num_traits::Zero;
 use oscoin_graph_api::{GraphAlgorithm, GraphWriter};
 use rand::SeedableRng;
-use rand_xorshift::XorShiftRng;
+use rand_xoshiro::Xoshiro256StarStar;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 
@@ -124,22 +124,22 @@ pub fn construct_network(meta_num: usize, contributions_num: usize) -> MockNetwo
     .unwrap()
 }
 
-pub fn run_osrank_naive(network: &MockNetwork, iter: u32, initial_seed: [u8; 16]) {
+pub fn run_osrank_naive(network: &MockNetwork, iter: u32, initial_seed: [u8; 32]) {
     let (algo, mut annotator, mut ctx) = construct_osrank_naive_algorithm();
     ctx.ledger_view.set_random_walks_num(iter);
     algo.execute(&mut ctx, &network, &mut annotator, initial_seed)
         .unwrap();
 }
 
-pub fn run_random_walk(network: &MockNetwork, iter: u32, initial_seed: [u8; 16]) {
+pub fn run_random_walk(network: &MockNetwork, iter: u32, initial_seed: [u8; 32]) {
     let mut mock_ledger = MockLedger::default();
 
     mock_ledger.set_random_walks_num(iter);
-    random_walk::<MockLedger, MockNetwork, XorShiftRng>(
+    random_walk::<MockLedger, MockNetwork, Xoshiro256StarStar>(
         None,
         &network,
         &mock_ledger,
-        &mut XorShiftRng::from_seed(initial_seed),
+        &mut Xoshiro256StarStar::from_seed(initial_seed),
     )
     .unwrap();
 }

--- a/src/types/walk.rs
+++ b/src/types/walk.rs
@@ -7,9 +7,8 @@ extern crate num_traits;
 extern crate petgraph;
 
 use fnv::FnvHashMap;
+
 use std::hash::Hash;
-use std::ops::Deref;
-use std::rc::Rc;
 
 #[derive(Debug, Default)]
 pub struct RandomWalks<Id>
@@ -22,7 +21,7 @@ where
 
 impl<Id> RandomWalks<Id>
 where
-    Id: Eq + Hash,
+    Id: Clone + Eq + Hash,
 {
     pub fn new() -> Self {
         RandomWalks {
@@ -84,8 +83,12 @@ where
     pub fn count_walks_from(&self, source: &Id) -> Count {
         self.random_walks
             .iter()
-            .filter(|rw| rw.random_walk_source.deref() == source)
+            .filter(|rw| rw.random_walk_source == *source)
             .count()
+    }
+
+    pub fn append(&mut self, mut rhs: Self) {
+        self.random_walks.append(&mut rhs.random_walks)
     }
 }
 
@@ -99,34 +102,32 @@ pub struct RandomWalk<Id>
 where
     Id: Hash + Eq,
 {
-    random_walk_source: Rc<Id>,
-    random_walk_visits: FnvHashMap<Rc<Id>, Count>,
+    random_walk_source: Id,
+    random_walk_visits: FnvHashMap<Id, Count>,
 }
 
 impl<Id> RandomWalk<Id>
 where
-    Id: Eq + Hash,
+    Id: Clone + Eq + Hash,
 {
     /// Creates a new `RandomWalk` by passing the source (i.e. beginning)
     /// of the walk. Note that this also counts as a visit, i.e. it's not
     /// necessary to call `add_next` after calling `new`.
     pub fn new(source: Id) -> Self {
-        let ix = Rc::new(source);
         let mut m = FnvHashMap::default();
-        m.insert(Rc::clone(&ix), 1);
+        m.insert(source.clone(), 1);
         RandomWalk {
-            random_walk_source: ix,
+            random_walk_source: source,
             random_walk_visits: m,
         }
     }
 
     /// Adds a segment (typically a graph's node) to the walk.
     pub fn add_next(&mut self, idx: Id) {
-        let ix = Rc::new(idx);
-        if let Some(visits) = self.random_walk_visits.get_mut(&ix) {
+        if let Some(visits) = self.random_walk_visits.get_mut(&idx) {
             *visits += 1;
         } else {
-            self.random_walk_visits.insert(ix, 1);
+            self.random_walk_visits.insert(idx, 1);
         }
     }
 

--- a/src/types/walk.rs
+++ b/src/types/walk.rs
@@ -5,15 +5,17 @@ extern crate fnv;
 extern crate fraction;
 extern crate num_traits;
 extern crate petgraph;
+extern crate rayon;
 
 use fnv::FnvHashMap;
 
+use rayon::prelude::*;
 use std::hash::Hash;
 
 #[derive(Debug, Default)]
 pub struct RandomWalks<Id>
 where
-    Id: Hash + Eq,
+    Id: Hash + Eq + Sync + Send,
 {
     /// A collection of random walks.
     random_walks: Vec<RandomWalk<Id>>,
@@ -21,7 +23,7 @@ where
 
 impl<Id> RandomWalks<Id>
 where
-    Id: Clone + Eq + Hash,
+    Id: Clone + Eq + Hash + Sync + Send,
 {
     pub fn new() -> Self {
         RandomWalks {
@@ -59,7 +61,7 @@ where
     /// ```
     pub fn count_visits(&self, idx: &Id) -> Count {
         self.random_walks
-            .iter()
+            .par_iter()
             .map(|rw| rw.count_visits(idx))
             .sum()
     }
@@ -100,7 +102,7 @@ type Count = usize;
 /// that element.
 pub struct RandomWalk<Id>
 where
-    Id: Hash + Eq,
+    Id: Hash + Eq + Sync + Send,
 {
     random_walk_source: Id,
     random_walk_visits: FnvHashMap<Id, Count>,
@@ -108,7 +110,7 @@ where
 
 impl<Id> RandomWalk<Id>
 where
-    Id: Clone + Eq + Hash,
+    Id: Clone + Eq + Hash + Sync + Send,
 {
     /// Creates a new `RandomWalk` by passing the source (i.e. beginning)
     /// of the walk. Note that this also counts as a visit, i.e. it's not


### PR DESCRIPTION
Fixed #71. There were a bunch of modifications I had to do in order to parallelise this:

1. Now we need to clone the `RNG` before passing it to each separate "thread" (it's not really a thread as we are using `rayon` under the hood so a thread pool is (re)used); this means that now the choice of _which_ `RNG` we use is essential for the algorithm to behave correctly. More specifically, we are now dropping the use of `XorShiftRng` due a cloning [pitfall](https://rust-random.github.io/rand/rand/trait.SeedableRng.html#method.from_rng) and we are using the `Xoshiro256StarStar` which is of higher quality and actually faster (7 Gb/s according to the "Rust rand book" vs 5 Gb/s);

2. After profiling the code, I did realise we had another bottleneck  (that @MeBrei warned me about for a while): our `RandomWalks::count_visits` was eating the majority of the time for `rank_network`, but luckily it was easily parallelisable;

## Results

Before parallelising the code, this is the result of running the `osrank-export-to-gephi` program:

<img width="955" alt="Screenshot 2019-09-18 at 12 30 51" src="https://user-images.githubusercontent.com/45846748/65148744-1bff4180-da21-11e9-80f1-113e7943fef4.png">

You will see how the full run takes 258 seconds _single threaded_ (you see how the system % says 98, i.e. this is not using all the cores). Afterwards:

<img width="955" alt="Screenshot 2019-09-18 at 13 19 40" src="https://user-images.githubusercontent.com/45846748/65148941-739dad00-da21-11e9-8682-afc3ac5050a1.png">

Note that despite _it seems_ this is slower, that's just `time` being confusing here: this is now using `332%` of CPU time (basically almost all my 4 cores) and if you compare the log timing you will see in the sequential case the time taken was ~5mins, whereas the parallel counterpart takes roughly 2.

**Important note:** It has to be noted that now the algorithm is optimised for large data structures, and for small graphs we are going to pay the price for initialising the `rayon` thread pool and possibly this could even make things slower, for smaller inputs.

@MeBrei It might be interesting to merge this piece of work and re-generate your nice criterion graphs, to see how the system is doing now.