### PR TITLE
Fix #66 (Add Normalised & NormalisedGraph)

### DIFF
--- a/benches/osrank_naive_development.rs
+++ b/benches/osrank_naive_development.rs
@@ -7,6 +7,7 @@ extern crate rand_xoshiro;
 use criterion::*;
 
 use osrank::algorithm::naive::{random_walk, rank_network};
+use osrank::algorithm::Normalised;
 use osrank::benchmarks::util::{
     construct_network, construct_network_small, construct_osrank_naive_algorithm, dev,
     run_osrank_naive, run_random_walk,
@@ -60,7 +61,7 @@ fn bench_rank_network(c: &mut Criterion) {
     let (_algo, mut annotator, mut ctx) = construct_osrank_naive_algorithm();
     ctx.ledger_view.set_random_walks_num(1);
 
-    let walks = random_walk::<MockLedger, MockNetwork, Xoshiro256StarStar>(
+    let walks = random_walk::<MockLedger, Normalised<MockNetwork>, Xoshiro256StarStar>(
         None,
         &network,
         &ctx.ledger_view,

--- a/bin/export_gephi.rs
+++ b/bin/export_gephi.rs
@@ -11,7 +11,7 @@ use clap::{App, Arg};
 
 use oscoin_graph_api::GraphAlgorithm;
 use osrank::algorithm::naive::{OsrankNaiveAlgorithm, OsrankNaiveMockContext};
-use osrank::algorithm::OsrankError;
+use osrank::algorithm::{Normalised, OsrankError};
 use osrank::exporters::{gexf, graphml};
 use osrank::importers::csv::{import_network, CsvImportError};
 use osrank::protocol_traits::ledger::{LedgerView, MockLedger};
@@ -105,10 +105,15 @@ fn main() -> Result<(), AppError> {
 
     debug!("Importing the network...");
 
-    let algo: Mock<OsrankNaiveAlgorithm<MockNetwork, MockLedger, MockAnnotator<MockNetwork>>> =
-        Mock {
-            unmock: OsrankNaiveAlgorithm::default(),
-        };
+    let algo: Mock<
+        OsrankNaiveAlgorithm<
+            Normalised<MockNetwork>,
+            MockLedger,
+            MockAnnotator<Normalised<MockNetwork>>,
+        >,
+    > = Mock {
+        unmock: OsrankNaiveAlgorithm::default(),
+    };
     let mut ctx = OsrankNaiveMockContext::default();
     ctx.ledger_view.set_random_walks_num(10);
 
@@ -123,7 +128,7 @@ fn main() -> Result<(), AppError> {
     debug!("Calculating the osrank (mock naive algorithm)...");
 
     let initial_seed = [0; 32];
-    let mut annotator: MockAnnotator<MockNetwork> = Default::default();
+    let mut annotator: MockAnnotator<Normalised<MockNetwork>> = Default::default();
 
     algo.execute(&mut ctx, &mut network, &mut annotator, initial_seed)?;
 

--- a/src/algorithm/mod.rs
+++ b/src/algorithm/mod.rs
@@ -3,7 +3,183 @@ pub mod incremental;
 /// Naive Osrank algorithm.
 pub mod naive;
 
+use crate::protocol_traits::graph::GraphExtras;
+use oscoin_graph_api::{
+    Data, Direction, EdgeRefs, Edges, Graph, GraphDataWriter, GraphWriter, Id, Nodes, NodesMut,
+};
+use quickcheck::{Arbitrary, Gen};
+
 /// Shared types between algorithms.
+
+/// Newtype-wapper that forces API producers and consumers to work with a
+/// normalised Graph, i.e. a `Graph` which edges have been collapsed into a
+/// single one.
+///
+/// You cannot "deconstruct" a `Normalised` graph. You can only create a new
+/// one.
+#[derive(Debug, Clone)]
+pub struct Normalised<G> {
+    normalised_graph: G,
+}
+
+/// NOTE: Do *not* implement a setter here (or make normalised_graph `pub`).
+/// The whole point of this newtype writter is to prevent using the incremental
+/// algorithm on a normalised graph, and viceversa use the naive one on an
+/// "un-normalised" one.
+impl<G> Normalised<G>
+where
+    G: Graph,
+{
+    pub fn new(normalised_graph: G) -> Self {
+        Normalised { normalised_graph }
+    }
+}
+
+/// Conceptually the companion for the `Normalised` newtype, this trait ensure
+/// that certain `GraphAlgorithm` implementation can be given only in terms
+/// of normalised graphs. This is the case for the "naive" algorithm, which
+/// requires a normalised input to be fed as input. However, nothing in the
+/// type signature of `osrank_naive` would prevent upstream code to call it
+/// with *any* type, provided it implement the `Graph` trait. This is why we
+/// need the `NormalisedGraph` trait: This embeds evidence in the type signature
+/// that a graph must be normalised, first.
+pub trait NormalisedGraph: private::NormalisedGraphSealed {}
+
+impl<G> NormalisedGraph for Normalised<G> where G: Graph {}
+
+impl<G> Default for Normalised<G>
+where
+    G: Default,
+{
+    fn default() -> Self {
+        Normalised {
+            normalised_graph: G::default(),
+        }
+    }
+}
+
+impl<A> Arbitrary for Normalised<A>
+where
+    A: Arbitrary,
+{
+    fn arbitrary<G: Gen>(g: &mut G) -> Self {
+        Normalised {
+            normalised_graph: A::arbitrary(g),
+        }
+    }
+}
+
+impl<G> GraphDataWriter for Normalised<G>
+where
+    G: GraphDataWriter,
+{
+    fn edge_data_mut(&mut self, id: &Id<Self::Edge>) -> Option<&mut Data<Self::Edge>> {
+        self.normalised_graph.edge_data_mut(id)
+    }
+
+    fn node_data_mut(&mut self, id: &Id<Self::Node>) -> Option<&mut Data<Self::Node>> {
+        self.normalised_graph.node_data_mut(id)
+    }
+}
+
+impl<G> GraphWriter for Normalised<G>
+where
+    G: GraphWriter,
+{
+    fn add_node(&mut self, node_id: Id<Self::Node>, node_metadata: Data<Self::Node>) {
+        self.normalised_graph.add_node(node_id, node_metadata)
+    }
+
+    fn remove_node(&mut self, node_id: Id<Self::Node>) {
+        self.normalised_graph.remove_node(node_id)
+    }
+
+    fn add_edge(
+        &mut self,
+        edge_id: Id<Self::Edge>,
+        source: &Id<Self::Node>,
+        to: &Id<Self::Node>,
+        weight: Self::Weight, // in this implementation, this is contained within the metadata
+        edge_metadata: Data<Self::Edge>,
+    ) {
+        self.normalised_graph
+            .add_edge(edge_id, source, to, weight, edge_metadata)
+    }
+
+    fn remove_edge(&mut self, edge_id: Id<Self::Edge>) {
+        self.normalised_graph.remove_edge(edge_id)
+    }
+
+    fn nodes_mut(&mut self) -> NodesMut<Self::Node> {
+        self.normalised_graph.nodes_mut()
+    }
+}
+
+impl<G> Graph for Normalised<G>
+where
+    G: Graph,
+{
+    type Node = G::Node;
+    type Edge = G::Edge;
+    type Weight = G::Weight;
+    type NodeData = G::NodeData;
+    type EdgeData = G::EdgeData;
+
+    fn neighbors(&self, node_id: &Id<Self::Node>) -> Nodes<Self::Node> {
+        self.normalised_graph.neighbors(node_id)
+    }
+
+    fn get_node(&self, id: &Id<Self::Node>) -> Option<&Self::Node> {
+        self.normalised_graph.get_node(id)
+    }
+
+    fn get_edge(&self, id: &Id<Self::Edge>) -> Option<&Self::Edge> {
+        self.normalised_graph.get_edge(id)
+    }
+
+    fn nodes(&self) -> Nodes<Self::Node> {
+        self.normalised_graph.nodes()
+    }
+
+    fn edges(&self, node: &Id<Self::Node>) -> Edges<Self::Edge> {
+        self.normalised_graph.edges(node)
+    }
+
+    fn edges_directed(
+        &self,
+        node_id: &Id<Self::Node>,
+        dir: Direction,
+    ) -> EdgeRefs<Id<Self::Node>, Id<Self::Edge>> {
+        self.normalised_graph.edges_directed(node_id, dir)
+    }
+}
+
+impl<G> GraphExtras for Normalised<G>
+where
+    G: GraphExtras,
+{
+    fn edge_count(&self) -> usize {
+        self.normalised_graph.edge_count()
+    }
+
+    fn node_count(&self) -> usize {
+        self.normalised_graph.node_count()
+    }
+
+    fn lookup_node_metadata(&self, node_id: &Id<Self::Node>) -> Option<&Data<Self::Node>> {
+        self.normalised_graph.lookup_node_metadata(node_id)
+    }
+
+    fn lookup_edge_metadata(&self, edge_id: &Id<Self::Edge>) -> Option<&Data<Self::Edge>> {
+        self.normalised_graph.lookup_edge_metadata(edge_id)
+    }
+
+    fn subgraph_by_nodes(&self, sub_nodes: Vec<&Id<Self::Node>>) -> Self {
+        Normalised {
+            normalised_graph: self.normalised_graph.subgraph_by_nodes(sub_nodes),
+        }
+    }
+}
 
 #[derive(Debug, PartialEq, Eq)]
 /// Errors that the `osrank` algorithm might throw.
@@ -18,4 +194,14 @@ impl From<rand::Error> for OsrankError {
     fn from(err: rand::Error) -> OsrankError {
         OsrankError::RngFailedToSplit(format!("{}", err))
     }
+}
+
+// See: https://rust-lang-nursery.github.io/api-guidelines/future-proofing.html
+// We want to avoid crate users to deliberately define this trait, which should
+// be fully controlled by the `osrank` crate.
+mod private {
+    use super::Normalised;
+    use oscoin_graph_api::Graph;
+    pub trait NormalisedGraphSealed {}
+    impl<G> NormalisedGraphSealed for Normalised<G> where G: Graph {}
 }

--- a/src/importers/csv.rs
+++ b/src/importers/csv.rs
@@ -9,6 +9,7 @@ extern crate serde;
 extern crate sprs;
 
 use crate::adjacency::new_network_matrix;
+use crate::algorithm::Normalised;
 use crate::linalg::{DenseMatrix, SparseMatrix};
 use crate::protocol_traits::ledger::LedgerView;
 use crate::types::network::{Artifact, ArtifactType, Dependency, DependencyType};
@@ -273,7 +274,7 @@ pub fn import_network<G, L, R>(
     //TODO(and) We want to consider maintainers at some point.
     _maintainers_csv_file: Option<csv::Reader<R>>,
     ledger_view: &L,
-) -> Result<G, CsvImportError>
+) -> Result<Normalised<G>, CsvImportError>
 where
     L: LedgerView,
     R: Read,
@@ -386,7 +387,7 @@ where
     }
 
     // Build a graph out of the matrix.
-    Ok(graph)
+    Ok(Normalised::new(graph))
 }
 
 /// Creates a (sparse) adjacency matrix for the dependencies.
@@ -453,6 +454,7 @@ mod tests {
     extern crate num_traits;
     extern crate tempfile;
 
+    use crate::algorithm::Normalised;
     use crate::protocol_traits::graph::GraphExtras;
     use crate::protocol_traits::ledger::MockLedger;
     use crate::types::network::{ArtifactType, DependencyType, Network};
@@ -503,7 +505,7 @@ mod tests {
 
         let mock_ledger = MockLedger::default();
 
-        let network: Network<f64> = super::import_network(
+        let network: Normalised<Network<f64>> = super::import_network(
             csv::ReaderBuilder::new()
                 .flexible(true)
                 .from_reader(deps_file),


### PR DESCRIPTION
This PR fixes #66, by creating a `Normalised` newtype wrapper over a `Graph` plus a companion [sealed](https://rust-lang-nursery.github.io/api-guidelines/future-proofing.html) `NormalisedGraph` trait to be used to prevent different `GraphAlgorithm` implementations to use the wrong "shape" for a `Graph`. More specifically, the "naive" algorithm assumes and requires the graph to be "normalised", i.e. a graph where each pair of nodes `(N1,N2)` has at most one outgoing edges from `N1` to `N2`, which is computed via some matrix arithmetic.

However, the montecarlo incremental algorithm relax this constraint and it's actually necessary for a graph to allow multiple edges, so that weight can be calculated on the fly. This means it would be a mistake trying to call one or the other algorithm with the wrong type of graph. 

This PR fixes that, by restricting the set of valid programs the Rust compiler will accept.

I wasn't able to fully exploit @cloudhead 's suggestion of making `Normalised` an instance of `Deref`, and unfortunately went with the boilerplate approach of trivially re-defining a bunch of traits that simply calls into the wrapped type.

 