### PR TITLE
Allow osrank to be run via the CLI with configurable params

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,11 @@ name = "osrank-export-to-gephi"
 path = "bin/export_gephi.rs"
 required-features = ["build-binary"]
 
+[[bin]]
+name = "osrank-rank" # Run osrank on some data, producing a csv file.
+path = "bin/rank.rs"
+required-features = ["build-binary"]
+
 [features]
 
 build-binary = ["reqwest", "clap", "failure", "failure_derive"]

--- a/bin/adjacency_matrix.rs
+++ b/bin/adjacency_matrix.rs
@@ -11,6 +11,11 @@ extern crate sprs;
 
 #[macro_use]
 extern crate failure_derive;
+#[cfg(test)]
+extern crate quickcheck;
+#[cfg(test)]
+#[macro_use(quickcheck)]
+extern crate quickcheck_macros;
 
 use clap::{App, Arg};
 use ndarray::Array2;
@@ -333,7 +338,8 @@ mod tests {
     use osrank::adjacency::new_network_matrix;
     use osrank::importers::csv::{ContribRow, ContributionsMetadata, DependenciesMetadata};
     use osrank::linalg::{
-        hadamard_mul, hadamard_mul_naive, normalise_rows, normalise_rows_mut, SparseMatrix,
+        hadamard_mul, hadamard_mul_naive, normalise_rows, normalise_rows_mut,
+        transpose_storage_csr, SparseMatrix,
     };
     use osrank::types::{HyperParams, Weight};
     use pretty_assertions::assert_eq;
@@ -474,7 +480,7 @@ mod tests {
         );
 
         // Transpose the matrix
-        let actual = super::transpose_storage_csr(&c);
+        let actual = transpose_storage_csr(&c);
 
         let expected = arr2(&[
             [Weight::new(7, 1), Weight::new(4, 1)],
@@ -490,7 +496,7 @@ mod tests {
         let input = mtxs.get_mtxs;
 
         // Transpose the matrix
-        let actual = super::transpose_storage_csr(&input.0);
+        let actual = transpose_storage_csr(&input.0);
         let expected = input.0.clone().transpose_into();
 
         // The inner storage of the two matrixes will be different, so we
@@ -516,7 +522,7 @@ mod tests {
 
         // Transpose the matrix and normalise it.
 
-        let actual = normalise_rows(&super::transpose_storage_csr(&c));
+        let actual = normalise_rows(&transpose_storage_csr(&c));
 
         let expected = arr2(&[
             [o, z, z],

--- a/bin/export_gephi.rs
+++ b/bin/export_gephi.rs
@@ -136,11 +136,11 @@ fn main() -> Result<(), AppError> {
     debug!("Exporting the network to .gexf ...");
 
     let gexf = GexfExporter::new(&network, &annotator, &out);
-    gexf.export_graph()?;
+    gexf.export()?;
 
     debug!("Exporting the network to .graphml ...");
     let graphml = GraphMlExporter::new(&network, &annotator, &out);
-    graphml.export_graph()?;
+    graphml.export()?;
 
     debug!("Done.");
 

--- a/bin/rank.rs
+++ b/bin/rank.rs
@@ -1,0 +1,136 @@
+#![allow(unknown_lints)]
+#![warn(clippy::all)]
+
+#[macro_use]
+extern crate log;
+extern crate env_logger;
+
+#[macro_use]
+extern crate failure_derive;
+
+extern crate clap;
+extern crate failure;
+extern crate ndarray;
+extern crate num_traits;
+extern crate osrank;
+extern crate serde;
+extern crate sprs;
+
+#[macro_use(quickcheck)]
+extern crate quickcheck_macros;
+
+use clap::{App, Arg};
+use itertools::Itertools;
+use ndarray::Array2;
+use osrank::adjacency::new_network_matrix;
+use osrank::collections::{Rank, WithLabels};
+use osrank::exporters::csv::CsvExporterError;
+use osrank::exporters::Exporter;
+use osrank::importers::csv::{
+    new_contribution_adjacency_matrix, new_dependency_adjacency_matrix, ContribRow,
+    ContributionsMetadata, CsvImportError, DepMetaRow, DependenciesMetadata, DisplayAsF64,
+};
+use osrank::linalg::{transpose_storage_csr, transpose_storage_naive, DenseMatrix, SparseMatrix};
+use osrank::types::mock::MockAnnotatorCsvExporter;
+use osrank::types::HyperParams;
+use sprs::binop::{add_mat_same_storage, scalar_mul_mat};
+use sprs::CsMat;
+
+use core::fmt::Debug;
+use num_traits::{Num, One, Signed, Zero};
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::rc::Rc;
+
+#[derive(Debug, Fail)]
+enum AppError {
+    // Returned in case of generic I/O error.
+    #[fail(display = "i/o error when reading/writing on the CSV file {}", _0)]
+    IOError(std::io::Error),
+    #[fail(display = "import error when reading/writing on the CSV file {}", _0)]
+    ImportError(CsvImportError),
+    #[fail(display = "export error when reading/writing on the CSV file {}", _0)]
+    ExportError(CsvExporterError),
+}
+
+impl From<std::io::Error> for AppError {
+    fn from(err: std::io::Error) -> AppError {
+        AppError::IOError(err)
+    }
+}
+
+impl From<CsvExporterError> for AppError {
+    fn from(err: CsvExporterError) -> AppError {
+        AppError::ExportError(err)
+    }
+}
+
+fn run_osrank(
+    deps_file: &str,
+    deps_meta_file: &str,
+    contrib_file: &str,
+    out_path: &str,
+) -> Result<(), AppError> {
+    // Export the ranks into a csv file.
+    let annotator = unimplemented!("todo");
+    let rank_exporter = MockAnnotatorCsvExporter::new(annotator, out_path);
+    rank_exporter.export()?;
+    Ok(())
+}
+
+fn main() -> Result<(), AppError> {
+    env_logger::init();
+    let matches = App::new("Run the Osrank algorithm and collect the result in a csv file.")
+        .arg(
+            Arg::with_name("dependencies")
+                .long("deps")
+                .help("Path to the <platform>_dependencies.csv file")
+                .takes_value(true)
+                .required(true),
+        )
+        .arg(
+            Arg::with_name("dependencies-with-metadata")
+                .long("deps-meta")
+                .help("Path to the <platform>_dependencies_meta.csv file")
+                .takes_value(true)
+                .required(true),
+        )
+        .arg(
+            Arg::with_name("contributions")
+                .long("contribs")
+                .help("Path to the <platform>_contributions.csv file")
+                .takes_value(true)
+                .required(true),
+        )
+        .arg(
+            Arg::with_name("output-path")
+                .short("o")
+                .help("Path to the output .csv file which will contain the ranks")
+                .takes_value(true)
+                .required(true),
+        )
+        .arg(
+            Arg::with_name("algorithm")
+                .short("a")
+                .help("The type of algorithm to use (naive|incremental).")
+                .takes_value(true)
+                .default_value("naive")
+                .required(false),
+        )
+        .get_matches();
+
+    run_osrank(
+        matches
+            .value_of("dependencies")
+            .expect("dependencies csv file not given."),
+        matches
+            .value_of("dependencies-with-metadata")
+            .expect("dependencies with metadata csv file not given."),
+        matches
+            .value_of("contributions")
+            .expect("contributions csv file not given."),
+        matches
+            .value_of("output-path")
+            .expect("output csv file not specified."),
+    )
+}

--- a/bin/rank.rs
+++ b/bin/rank.rs
@@ -16,31 +16,19 @@ extern crate osrank;
 extern crate serde;
 extern crate sprs;
 
-#[macro_use(quickcheck)]
-extern crate quickcheck_macros;
-
 use clap::{App, Arg};
-use itertools::Itertools;
-use ndarray::Array2;
-use osrank::adjacency::new_network_matrix;
-use osrank::collections::{Rank, WithLabels};
+use core::fmt::Debug;
+use oscoin_graph_api::GraphAlgorithm;
+use std::fs::File;
+
+use osrank::algorithm::naive::{OsrankNaiveAlgorithm, OsrankNaiveMockContext};
+use osrank::algorithm::{Normalised, OsrankError};
 use osrank::exporters::csv::CsvExporterError;
 use osrank::exporters::Exporter;
-use osrank::importers::csv::{
-    new_contribution_adjacency_matrix, new_dependency_adjacency_matrix, ContribRow,
-    ContributionsMetadata, CsvImportError, DepMetaRow, DependenciesMetadata, DisplayAsF64,
-};
-use osrank::linalg::{transpose_storage_csr, transpose_storage_naive, DenseMatrix, SparseMatrix};
-use osrank::types::mock::MockAnnotatorCsvExporter;
-use osrank::types::HyperParams;
-use sprs::binop::{add_mat_same_storage, scalar_mul_mat};
-use sprs::CsMat;
-
-use core::fmt::Debug;
-use num_traits::{Num, One, Signed, Zero};
-use std::fs::{File, OpenOptions};
-use std::io::Write;
-use std::rc::Rc;
+use osrank::importers::csv::{import_network, CsvImportError};
+use osrank::protocol_traits::ledger::{LedgerView, MockLedger};
+use osrank::types;
+use osrank::types::mock::{Mock, MockAnnotator, MockAnnotatorCsvExporter, MockNetwork};
 
 #[derive(Debug, Fail)]
 enum AppError {
@@ -51,11 +39,22 @@ enum AppError {
     ImportError(CsvImportError),
     #[fail(display = "export error when reading/writing on the CSV file {}", _0)]
     ExportError(CsvExporterError),
+    #[fail(
+        display = "export when running the Osrank algorithm on the graph {}",
+        _0
+    )]
+    AlgorithmError(OsrankError),
 }
 
 impl From<std::io::Error> for AppError {
     fn from(err: std::io::Error) -> AppError {
         AppError::IOError(err)
+    }
+}
+
+impl From<CsvImportError> for AppError {
+    fn from(err: CsvImportError) -> AppError {
+        AppError::ImportError(err)
     }
 }
 
@@ -65,17 +64,106 @@ impl From<CsvExporterError> for AppError {
     }
 }
 
+impl From<OsrankError> for AppError {
+    fn from(err: OsrankError) -> AppError {
+        AppError::AlgorithmError(err)
+    }
+}
+
+#[derive(Debug)]
+pub enum OsrankAlgorithm {
+    Naive,
+    Incremental,
+}
+
 fn run_osrank(
     deps_file: &str,
     deps_meta_file: &str,
     contrib_file: &str,
     out_path: &str,
+    osrank_algo: OsrankAlgorithm,
+    ledger: MockLedger,
 ) -> Result<(), AppError> {
+    let deps_csv_file = File::open(deps_file)?;
+    let deps_meta_csv_file = File::open(deps_meta_file)?;
+    let contribs_csv_file = File::open(contrib_file)?;
+
+    debug!("Importing the network...");
+
+    let (algo, mut ctx, network) = match osrank_algo {
+        OsrankAlgorithm::Naive => {
+            debug!("Selecting the naive algorithm...");
+            let a: Mock<
+                OsrankNaiveAlgorithm<
+                    Normalised<MockNetwork>,
+                    MockLedger,
+                    MockAnnotator<Normalised<MockNetwork>>,
+                >,
+            > = Mock {
+                unmock: OsrankNaiveAlgorithm::default(),
+            };
+            let mut ctx = OsrankNaiveMockContext::default();
+            ctx.ledger_view = ledger;
+            let network = import_network::<MockNetwork, MockLedger, File>(
+                csv::Reader::from_reader(deps_csv_file),
+                csv::Reader::from_reader(deps_meta_csv_file),
+                csv::Reader::from_reader(contribs_csv_file),
+                None,
+                &ctx.ledger_view,
+            )?;
+
+            (a, ctx, network)
+        }
+        OsrankAlgorithm::Incremental => {
+            debug!("Selecting the incremental (not-implemented) algorithm...");
+            let a: Mock<
+                OsrankNaiveAlgorithm<
+                    Normalised<MockNetwork>,
+                    MockLedger,
+                    MockAnnotator<Normalised<MockNetwork>>,
+                >,
+            > = Mock {
+                unmock: OsrankNaiveAlgorithm::default(),
+            };
+            let mut ctx = OsrankNaiveMockContext::default();
+            ctx.ledger_view = ledger;
+            let network = import_network::<MockNetwork, MockLedger, File>(
+                csv::Reader::from_reader(deps_csv_file),
+                csv::Reader::from_reader(deps_meta_csv_file),
+                csv::Reader::from_reader(contribs_csv_file),
+                None,
+                &ctx.ledger_view,
+            )?;
+
+            (a, ctx, network)
+        }
+    };
+
+    debug!(
+        "{}",
+        format!("Calculating the osrank ({:#?} algorithm)...", osrank_algo)
+    );
+
+    let initial_seed = [0; 32];
+    let mut annotator: MockAnnotator<Normalised<MockNetwork>> = Default::default();
+
+    algo.execute(&mut ctx, &network, &mut annotator, initial_seed)?;
+
+    debug!("Exporting the ranks into a .csv file ...");
     // Export the ranks into a csv file.
-    let annotator = unimplemented!("todo");
     let rank_exporter = MockAnnotatorCsvExporter::new(annotator, out_path);
     rank_exporter.export()?;
+
+    debug!("Done.");
     Ok(())
+}
+
+fn parse_algorithm(algo_str: &str) -> Option<OsrankAlgorithm> {
+    match algo_str {
+        "naive" => Some(OsrankAlgorithm::Naive),
+        "incremental" => Some(OsrankAlgorithm::Incremental),
+        _ => None,
+    }
 }
 
 fn main() -> Result<(), AppError> {
@@ -117,7 +205,66 @@ fn main() -> Result<(), AppError> {
                 .default_value("naive")
                 .required(false),
         )
+        .arg(
+            Arg::with_name("tau")
+                .help("The value of 'tau', i.e. the pruning threshold for the trustrank phase. (Default: 0.0)")
+                .takes_value(true)
+                .default_value("0.0")
+                .required(false),
+        )
+        .arg(
+            Arg::with_name("iter")
+                .short("i")
+                .help("The number of iterations (R) for each random walk (Default: 10)")
+                .takes_value(true)
+                .default_value("10")
+                .required(false),
+        )
+        .arg(
+            Arg::with_name("accounts-damping-factor")
+                .help("The damping factor for accounts (Default: 0.85)")
+                .takes_value(true)
+                .default_value("0.85")
+                .required(false),
+        )
+        .arg(
+            Arg::with_name("projects-damping-factor")
+                .help("The damping factor for projects (Default: 0.85)")
+                .takes_value(true)
+                .default_value("0.85")
+                .required(false),
+        )
         .get_matches();
+
+    let tau = matches
+        .value_of("tau")
+        .and_then(|s: &str| s.parse::<types::Tau>().ok())
+        .unwrap_or(0.0);
+
+    let r = matches
+        .value_of("iter")
+        .and_then(|s: &str| s.parse::<types::R>().ok())
+        .unwrap_or(10);
+
+    let acc_damping_factor = matches
+        .value_of("accounts-damping-factor")
+        .and_then(|s: &str| s.parse::<f64>().ok())
+        .unwrap_or(0.85);
+
+    let prj_damping_factor = matches
+        .value_of("projects-damping-factor")
+        .and_then(|s: &str| s.parse::<f64>().ok())
+        .unwrap_or(0.85);
+
+    let damping_factors = types::DampingFactors {
+        project: prj_damping_factor,
+        account: acc_damping_factor,
+    };
+
+    let mut ledger_view = MockLedger::default();
+    ledger_view.set_tau(tau);
+    ledger_view.set_random_walks_num(r);
+    ledger_view.set_damping_factors(damping_factors);
 
     run_osrank(
         matches
@@ -132,5 +279,10 @@ fn main() -> Result<(), AppError> {
         matches
             .value_of("output-path")
             .expect("output csv file not specified."),
+        matches
+            .value_of("algorithm")
+            .and_then(parse_algorithm)
+            .expect("Failed to parse algorithm. Possible choices: naive|incremental."),
+        ledger_view,
     )
 }

--- a/src/algorithm/incremental.rs
+++ b/src/algorithm/incremental.rs
@@ -39,7 +39,7 @@ where
     <G as Graph>::Weight:
         Default + Clone + PartialOrd + for<'x> AddAssign<&'x G::Weight> + SampleUniform,
 {
-    unimplemented!("not implemented yet.");
+    unimplemented!("The incremental algorithm is not implemented yet.");
 }
 
 pub struct OsrankIncrementalAlgorithm<'a, G: 'a, L, A: 'a> {

--- a/src/algorithm/mod.rs
+++ b/src/algorithm/mod.rs
@@ -181,7 +181,7 @@ where
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Display, PartialEq, Eq)]
 /// Errors that the `osrank` algorithm might throw.
 pub enum OsrankError {
     /// Generic, catch-all error for things which can go wrong during the

--- a/src/exporters/csv.rs
+++ b/src/exporters/csv.rs
@@ -31,7 +31,7 @@ where
 
     for (node_id, rank) in annotator.sorted_by(|(_, v1), (_, v2)| v2.partial_cmp(v1).unwrap()) {
         output_csv.write_all(
-            format!("{} {:.32}\n", node_id, to_f64(rank))
+            format!("{},{:.32}\n", node_id, to_f64(rank))
                 .as_str()
                 .as_bytes(),
         )?;

--- a/src/exporters/csv.rs
+++ b/src/exporters/csv.rs
@@ -1,0 +1,41 @@
+use itertools::Itertools;
+use std::fs::OpenOptions;
+use std::io::Write;
+
+#[derive(Debug, Display)]
+pub enum CsvExporterError {
+    IOError(std::io::Error),
+}
+
+impl From<std::io::Error> for CsvExporterError {
+    fn from(err: std::io::Error) -> CsvExporterError {
+        CsvExporterError::IOError(err)
+    }
+}
+
+/// Given a (id,rank) iterator, write into a `.csv` file the (sorted) rank,
+/// from the highest to the lowest.
+pub fn export_rank_to_csv<K, V>(
+    annotator: impl Iterator<Item = (K, V)>,
+    to_f64: Box<dyn Fn(V) -> f64>,
+    out_path: &str,
+) -> Result<(), CsvExporterError>
+where
+    V: PartialOrd,
+    K: std::fmt::Display,
+{
+    let mut output_csv = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(out_path)?;
+
+    for (node_id, rank) in annotator.sorted_by(|(_, v1), (_, v2)| v2.partial_cmp(v1).unwrap()) {
+        output_csv.write_all(
+            format!("{} {:.32}\n", node_id, to_f64(rank))
+                .as_str()
+                .as_bytes(),
+        )?;
+    }
+
+    Ok(())
+}

--- a/src/exporters/gexf.rs
+++ b/src/exporters/gexf.rs
@@ -305,7 +305,7 @@ where
 {
     type ExporterOutput = ();
     type ExporterError = ExportError;
-    fn export_graph(self) -> Result<Self::ExporterOutput, Self::ExporterError> {
+    fn export(self) -> Result<Self::ExporterOutput, Self::ExporterError> {
         let pth = self.out_path.to_owned() + ".gexf";
         let out_with_ext = Path::new(&pth);
         export_graph_impl(self.graph, self.annotator, &out_with_ext)

--- a/src/exporters/gexf.rs
+++ b/src/exporters/gexf.rs
@@ -4,7 +4,7 @@
 use num_traits::Zero;
 use oscoin_graph_api::{Direction, EdgeRef, Graph, GraphObject};
 
-use super::{size_from_rank, NodeType, Rank, RgbColor};
+use super::{size_from_rank, Exporter, NodeType, Rank, RgbColor};
 use crate::types::mock::KeyValueAnnotator;
 
 use std::convert::TryInto;
@@ -248,7 +248,7 @@ where
 ///
 /// This file can then be imported into one of the many graph visualisers,
 /// like [Gephi](https://gephi.org/).
-pub fn export_graph<G, V>(
+fn export_graph_impl<G, V>(
     g: &G,
     annotator: &KeyValueAnnotator<<G::Node as GraphObject>::Id, V>,
     out: &Path,
@@ -267,4 +267,47 @@ where
     out_file.write_all(GEXF_FOOTER.as_bytes())?;
 
     Ok(())
+}
+
+pub struct GexfExporter<'a, G, V>
+where
+    G: Graph,
+{
+    graph: &'a G,
+    annotator: &'a KeyValueAnnotator<<G::Node as GraphObject>::Id, V>,
+    out_path: &'a str,
+}
+
+impl<'a, G, V> GexfExporter<'a, G, V>
+where
+    G: Graph,
+{
+    pub fn new(
+        graph: &'a G,
+        annotator: &'a KeyValueAnnotator<<G::Node as GraphObject>::Id, V>,
+        out_path: &'a str,
+    ) -> Self {
+        GexfExporter {
+            graph,
+            annotator,
+            out_path,
+        }
+    }
+}
+
+impl<'a, G, V> Exporter for GexfExporter<'a, G, V>
+where
+    G: Graph,
+    <G::Node as GraphObject>::Id: IntoGexfXml + Clone + TryInto<String> + Eq + Hash,
+    <G::Node as GraphObject>::Data: Clone + Into<NodeType>,
+    <G::Edge as GraphObject>::Id: IntoGexfXml + Clone,
+    V: Into<Rank<f64>> + Zero + Clone,
+{
+    type ExporterOutput = ();
+    type ExporterError = ExportError;
+    fn export_graph(self) -> Result<Self::ExporterOutput, Self::ExporterError> {
+        let pth = self.out_path.to_owned() + ".gexf";
+        let out_with_ext = Path::new(&pth);
+        export_graph_impl(self.graph, self.annotator, &out_with_ext)
+    }
 }

--- a/src/exporters/graphml.rs
+++ b/src/exporters/graphml.rs
@@ -337,7 +337,7 @@ where
 {
     type ExporterOutput = ();
     type ExporterError = ExportError;
-    fn export_graph(self) -> Result<Self::ExporterOutput, Self::ExporterError> {
+    fn export(self) -> Result<Self::ExporterOutput, Self::ExporterError> {
         let pth = self.out_path.to_owned() + ".graphml";
         let out_with_ext = Path::new(&pth);
         export_graph_impl(self.graph, self.annotator, &out_with_ext)

--- a/src/exporters/mod.rs
+++ b/src/exporters/mod.rs
@@ -9,6 +9,12 @@ use crate::types::Osrank;
 use fraction::ToPrimitive;
 use std::marker::PhantomData;
 
+pub trait Exporter {
+    type ExporterOutput;
+    type ExporterError;
+    fn export_graph(self) -> Result<Self::ExporterOutput, Self::ExporterError>;
+}
+
 /// A rank for a node.
 ///
 /// The `PhantomData` stores the type we need to convert _from_.

--- a/src/exporters/mod.rs
+++ b/src/exporters/mod.rs
@@ -1,3 +1,5 @@
+/// Exports the rank of a graph into CSV.
+pub mod csv;
 pub mod dot;
 /// Exports a Graph into GEXF (Gephi Exchange Format).
 pub mod gexf;
@@ -7,52 +9,12 @@ pub mod graphml;
 use crate::types::network::ArtifactType;
 use crate::types::Osrank;
 use fraction::ToPrimitive;
-use itertools::Itertools;
-use std::collections::HashMap;
-use std::fs::OpenOptions;
-use std::io::Write;
-use std::iter::IntoIterator;
 use std::marker::PhantomData;
 
 pub trait Exporter {
     type ExporterOutput;
     type ExporterError;
     fn export(self) -> Result<Self::ExporterOutput, Self::ExporterError>;
-}
-
-pub enum CsvExporterError {
-    IOError(std::io::Error),
-}
-
-impl From<std::io::Error> for CsvExporterError {
-    fn from(err: std::io::Error) -> CsvExporterError {
-        CsvExporterError::IOError(err)
-    }
-}
-
-/// Given a (id,rank) iterator, write into a `.csv` file the (sorted) rank,
-/// from the highest to the lowest.
-pub fn export_rank_to_csv<K, V>(
-    annotator: impl IntoIterator<Item = (K, V), IntoIter = <HashMap<K, V> as IntoIterator>::IntoIter>,
-    out_path: &str,
-) -> Result<(), CsvExporterError>
-where
-    V: ToPrimitive + PartialOrd + std::fmt::Display,
-    K: std::fmt::Display,
-{
-    let mut output_csv = OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(out_path)?;
-
-    for (node_id, rank) in annotator
-        .into_iter()
-        .sorted_by(|(_, v1), (_, v2)| v2.partial_cmp(v1).unwrap())
-    {
-        output_csv.write_all(format!("{} {:.32}\n", node_id, rank).as_str().as_bytes())?;
-    }
-
-    Ok(())
 }
 
 /// A rank for a node.

--- a/src/exporters/mod.rs
+++ b/src/exporters/mod.rs
@@ -7,12 +7,52 @@ pub mod graphml;
 use crate::types::network::ArtifactType;
 use crate::types::Osrank;
 use fraction::ToPrimitive;
+use itertools::Itertools;
+use std::collections::HashMap;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::iter::IntoIterator;
 use std::marker::PhantomData;
 
 pub trait Exporter {
     type ExporterOutput;
     type ExporterError;
-    fn export_graph(self) -> Result<Self::ExporterOutput, Self::ExporterError>;
+    fn export(self) -> Result<Self::ExporterOutput, Self::ExporterError>;
+}
+
+pub enum CsvExporterError {
+    IOError(std::io::Error),
+}
+
+impl From<std::io::Error> for CsvExporterError {
+    fn from(err: std::io::Error) -> CsvExporterError {
+        CsvExporterError::IOError(err)
+    }
+}
+
+/// Given a (id,rank) iterator, write into a `.csv` file the (sorted) rank,
+/// from the highest to the lowest.
+pub fn export_rank_to_csv<K, V>(
+    annotator: impl IntoIterator<Item = (K, V), IntoIter = <HashMap<K, V> as IntoIterator>::IntoIter>,
+    out_path: &str,
+) -> Result<(), CsvExporterError>
+where
+    V: ToPrimitive + PartialOrd + std::fmt::Display,
+    K: std::fmt::Display,
+{
+    let mut output_csv = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(out_path)?;
+
+    for (node_id, rank) in annotator
+        .into_iter()
+        .sorted_by(|(_, v1), (_, v2)| v2.partial_cmp(v1).unwrap())
+    {
+        output_csv.write_all(format!("{} {:.32}\n", node_id, rank).as_str().as_bytes())?;
+    }
+
+    Ok(())
 }
 
 /// A rank for a node.

--- a/src/types/mock.rs
+++ b/src/types/mock.rs
@@ -3,6 +3,7 @@
 
 extern crate oscoin_graph_api;
 
+use crate::exporters::{export_rank_to_csv, CsvExporterError, Exporter};
 use crate::types::network::{Artifact, DependencyType, Network};
 use crate::types::Osrank;
 use crate::util::quickcheck::frequency;
@@ -131,5 +132,27 @@ impl Default for MockAnnotator<MockNetwork> {
         KeyValueAnnotator {
             annotator: Default::default(),
         }
+    }
+}
+
+pub struct MockAnnotatorCsvExporter<'a> {
+    pub annotator: MockAnnotator<MockNetwork>,
+    pub out_path: &'a str,
+}
+
+impl<'a> MockAnnotatorCsvExporter<'a> {
+    pub fn new(annotator: MockAnnotator<MockNetwork>, out_path: &'a str) -> Self {
+        MockAnnotatorCsvExporter {
+            annotator,
+            out_path,
+        }
+    }
+}
+
+impl<'a> Exporter for MockAnnotatorCsvExporter<'a> {
+    type ExporterOutput = ();
+    type ExporterError = CsvExporterError;
+    fn export(self) -> Result<Self::ExporterOutput, Self::ExporterError> {
+        export_rank_to_csv(self.annotator.annotator, self.out_path)
     }
 }

--- a/src/types/mock.rs
+++ b/src/types/mock.rs
@@ -3,10 +3,12 @@
 
 extern crate oscoin_graph_api;
 
-use crate::exporters::{export_rank_to_csv, CsvExporterError, Exporter};
+use crate::exporters::csv::{export_rank_to_csv, CsvExporterError};
+use crate::exporters::Exporter;
 use crate::types::network::{Artifact, DependencyType, Network};
 use crate::types::Osrank;
 use crate::util::quickcheck::frequency;
+use fraction::ToPrimitive;
 use oscoin_graph_api::{Graph, GraphAnnotator, GraphObject, GraphWriter};
 use quickcheck::{Arbitrary, Gen};
 use rand::Rng;
@@ -153,6 +155,10 @@ impl<'a> Exporter for MockAnnotatorCsvExporter<'a> {
     type ExporterOutput = ();
     type ExporterError = CsvExporterError;
     fn export(self) -> Result<Self::ExporterOutput, Self::ExporterError> {
-        export_rank_to_csv(self.annotator.annotator, self.out_path)
+        export_rank_to_csv(
+            self.annotator.annotator.into_iter(),
+            Box::new(|v: Osrank| v.to_f64().unwrap_or(0.0)),
+            self.out_path,
+        )
     }
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -158,6 +158,7 @@ impl Zero for Weight {
 }
 
 /// The hyperparams from the paper, which are used to weight the edges.
+#[derive(Debug)]
 pub struct HyperParams {
     pub contrib_factor: Weight,
     pub contrib_prime_factor: Weight,

--- a/src/types/walk.rs
+++ b/src/types/walk.rs
@@ -157,16 +157,32 @@ where
 ///    calculation;
 /// 2. Ensure that the entire `Graph` is explored and that random walks
 ///    eventually "explore" all the nodes.
+#[derive(Debug)]
 pub struct SeedSet<Id> {
     trusted_nodes: Vec<Id>,
 }
 
 impl<I> SeedSet<I> {
+    /// Creates a new empty `SeedSet` collection.
+    pub fn new() -> Self {
+        SeedSet {
+            trusted_nodes: Vec::new(),
+        }
+    }
+
     /// Creates a new `SeedSet` collection from a vector of identifiers.
     pub fn from(nodes: Vec<I>) -> Self {
         SeedSet {
             trusted_nodes: nodes,
         }
+    }
+
+    pub fn len(&self) -> usize {
+        self.trusted_nodes.len()
+    }
+
+    pub fn add_node(&mut self, node: I) {
+        self.trusted_nodes.push(node)
     }
 
     pub fn is_empty(&self) -> bool {
@@ -272,5 +288,4 @@ mod tests {
 
         assert_eq!(walks.count_walks_from(&String::from("a")), 3);
     }
-
 }


### PR DESCRIPTION
This PR allows `osrank` to be run from the CLI and override pretty much every possible parameter, making the `osrank-rank` executable very suitable for simulations.

The only thing we cannot override is the initial RNG seed, but I don't think we will need this any time soon, and it shouldn't matter too much for the simulations.