### PR TITLE
Fix #88 (pass rngSeed CLI)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ required-features = ["build-binary"]
 
 [features]
 
-build-binary = ["reqwest", "clap", "failure", "failure_derive"]
+build-binary = ["reqwest", "clap", "failure", "failure_derive", "arrayref"]
 
 [dependencies]
 
@@ -86,6 +86,7 @@ reqwest = { version = "^0.9", optional = true }
 clap = { version = "^2.33", optional = true }
 failure = { version = "0.1.5", optional = true}
 failure_derive = { version = "0.1.5", optional = true}
+arrayref = { version = "0.3.5", optional = true}
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"


### PR DESCRIPTION
Fixes #88. Now `osrank-rank` can be passed an extra `--initial-seed <u64>` argument to override the initial RNG seed. For example:

```
RUST_LOG=debug ./target/release/osrank-rank \
--contribs ../osrank-rs-ecosystems/ecosystems/cargo_contributions.csv \
--deps ../osrank-rs-ecosystems/ecosystems/cargo_dependencies.csv \
--deps-meta ../osrank-rs-ecosystems/ecosystems/cargo_dependencies_meta.csv \
-o ../cargo_rank3.csv --iter 1 --initial-seed 42
```

Fixes #88 .